### PR TITLE
Compare timestamps using Equal

### DIFF
--- a/usecase/indexing/summarize.go
+++ b/usecase/indexing/summarize.go
@@ -145,7 +145,7 @@ func (uc *summarizeUseCase) summarizeValidatorSeq(interval types.SummaryInterval
 
 		var rawEraSeqSummary store.ValidatorEraSeqSummary
 		for _, rawEraSummaryItem := range rawEraSummaryItems {
-			if rawEraSummaryItem.StashAccount == rawSessionSummaryItem.StashAccount && rawEraSummaryItem.TimeBucket == rawSessionSummaryItem.TimeBucket {
+			if rawEraSummaryItem.StashAccount == rawSessionSummaryItem.StashAccount && rawEraSummaryItem.TimeBucket.Equal(rawSessionSummaryItem.TimeBucket) {
 				rawEraSeqSummary = rawEraSummaryItem
 			}
 		}


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=a24a1e13030246d68b4decd5117d479c)

comparing time_bucket with `==` was always returning 'false' in the worker when summarizing ran after indexing, as a result data related to validator_era_sequences is always 0 in validator_summary table (maybe due to some gorm cache? 🤷 running a one-off run `-cmd indexer_summarize` works fine). Switching to `time.Equal` resolves this.

before:
```
polkadothub=#  select created_at, updated_at, time_interval, time_bucket, reward_points_max,commission_max,stakers_stake_max from validator_summary;
          created_at           |          updated_at           | time_interval |      time_bucket       | reward_points_max | commission_max | stakers_stake_max
-------------------------------+-------------------------------+---------------+------------------------+-------------------+----------------+-------------------
 2020-09-21 22:27:55.019161-04 | 2020-09-21 22:28:43.016232-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.021059-04 | 2020-09-21 22:28:43.017342-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.022269-04 | 2020-09-21 22:28:43.018334-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.023424-04 | 2020-09-21 22:28:43.019313-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.024456-04 | 2020-09-21 22:28:43.020425-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.025534-04 | 2020-09-21 22:28:43.021684-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.026557-04 | 2020-09-21 22:28:43.022778-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.02761-04  | 2020-09-21 22:28:43.024425-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.028599-04 | 2020-09-21 22:28:43.026476-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.029636-04 | 2020-09-21 22:28:43.028057-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.030625-04 | 2020-09-21 22:28:43.029442-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.031603-04 | 2020-09-21 22:28:43.030819-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.03253-04  | 2020-09-21 22:28:43.032238-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.033521-04 | 2020-09-21 22:28:43.033956-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.034604-04 | 2020-09-21 22:28:43.034994-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.035992-04 | 2020-09-21 22:28:43.035978-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.03734-04  | 2020-09-21 22:28:43.037044-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.038692-04 | 2020-09-21 22:28:43.03846-04  | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
 2020-09-21 22:27:55.040111-04 | 2020-09-21 22:28:43.039886-04 | day           | 2020-06-18 00:00:00-04 |                 0 |              0 |                 0
```


now:
```
polkadothub=#  select created_at, updated_at, time_interval, time_bucket, reward_points_max,commission_max,stakers_stake_max from validator_summary;
          created_at           |          updated_at           | time_interval |      time_bucket       | reward_points_max | commission_max | stakers_stake_max
-------------------------------+-------------------------------+---------------+------------------------+-------------------+----------------+-------------------
 2020-09-21 22:27:55.024456-04 | 2020-09-21 22:27:55.024456-04 | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 66431288181887544
 2020-09-21 22:27:55.025534-04 | 2020-09-21 22:27:55.025534-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       10000000 | 68461179017051960
 2020-09-21 22:27:55.026557-04 | 2020-09-21 22:27:55.026557-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       10000000 | 68809745145996800
 2020-09-21 22:27:55.02761-04  | 2020-09-21 22:27:55.02761-04  | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 66641056610971240
 2020-09-21 22:27:55.028599-04 | 2020-09-21 22:27:55.028599-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       30000000 | 68457575819220872
 2020-09-21 22:27:55.029636-04 | 2020-09-21 22:27:55.029636-04 | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 66638717425803008
 2020-09-21 22:27:55.030625-04 | 2020-09-21 22:27:55.030625-04 | day           | 2020-06-18 00:00:00-04 |                20 |     1000000000 | 68878119111924928
 2020-09-21 22:27:55.031603-04 | 2020-09-21 22:27:55.031603-04 | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 66621729610131992
 2020-09-21 22:27:55.03253-04  | 2020-09-21 22:27:55.03253-04  | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 67627084573128864
 2020-09-21 22:27:55.033521-04 | 2020-09-21 22:27:55.033521-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       10000000 | 68905408194094760
 2020-09-21 22:27:55.034604-04 | 2020-09-21 22:27:55.034604-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       30000000 | 67961274891279472
 2020-09-21 22:27:55.019161-04 | 2020-09-21 22:27:55.019161-04 | day           | 2020-06-18 00:00:00-04 |                 0 |      100000000 | 19043162160355728
 2020-09-21 22:27:55.021059-04 | 2020-09-21 22:27:55.021059-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       30000000 | 68452006802619208
 2020-09-21 22:27:55.022269-04 | 2020-09-21 22:27:55.022269-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       50000000 | 81850500000000000
 2020-09-21 22:27:55.023424-04 | 2020-09-21 22:27:55.023424-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       30000000 | 64031921774700544
 2020-09-21 22:27:55.035992-04 | 2020-09-21 22:27:55.035992-04 | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 68717147631036848
 2020-09-21 22:27:55.03734-04  | 2020-09-21 22:27:55.03734-04  | day           | 2020-06-18 00:00:00-04 |                 0 |     1000000000 | 66640035584039064
 2020-09-21 22:27:55.038692-04 | 2020-09-21 22:27:55.038692-04 | day           | 2020-06-18 00:00:00-04 |                 0 |       30000000 | 68452876664988176
 2020-09-21 22:27:55.040111-04 | 2020-09-21 22:27:55.040111-04 | day           | 2020-06-18 00:00:00-04 |                 0 |      100000000 | 66674869466697184
 2020-09-21 22:27:55.041641-04 | 2020-09-21 22:27:55.041641-04 | day           | 2020-06-18 00:00:00-04 |                 0 |      100000000 | 71193008807235584
(20 rows)
```
