### PR TITLE
Update indexer config

### DIFF
--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -234,6 +234,10 @@ func (p *indexingPipeline) Backfill(ctx context.Context, backfillCfg BackfillCon
 		return err
 	}
 
+	if err := reportCreator.createIfNotExists(model.ReportKindSequentialReindex, model.ReportKindParallelReindex); err != nil {
+		return err
+	}
+
 	if err := p.db.Syncables.SetProcessedAtForRange(reportCreator.report.ID, source.startHeight, source.endHeight); err != nil {
 		return err
 	}

--- a/indexer_config.json
+++ b/indexer_config.json
@@ -4,7 +4,12 @@
             "id": 1,
             "targets": [1,2,3,4,5,6],
             "parallel": false
-        }
+        },
+        {
+          "id": 2,
+          "targets": [2,4],
+          "parallel": true
+      }
     ],
     "shared_tasks": [
         "MainSyncer"

--- a/usecase/indexing/backfill.go
+++ b/usecase/indexing/backfill.go
@@ -2,6 +2,7 @@ package indexing
 
 import (
 	"context"
+
 	"github.com/figment-networks/polkadothub-indexer/client"
 	"github.com/figment-networks/polkadothub-indexer/config"
 	"github.com/figment-networks/polkadothub-indexer/indexer"
@@ -35,9 +36,9 @@ type BackfillUseCaseConfig struct {
 }
 
 func (uc *backfillUseCase) Execute(ctx context.Context, useCaseConfig BackfillUseCaseConfig) error {
-	//if err := uc.canExecute(); err != nil {
-	//	return err
-	//}
+	if err := uc.canExecute(); err != nil {
+		return err
+	}
 
 	indexingPipeline, err := indexer.NewPipeline(uc.cfg, uc.db, uc.client)
 	if err != nil {

--- a/usecase/indexing/backfill.go
+++ b/usecase/indexing/backfill.go
@@ -57,9 +57,8 @@ func (uc *backfillUseCase) canExecute() error {
 	if _, err := uc.db.Reports.FindNotCompletedByKind(model.ReportKindSequentialReindex, model.ReportKindParallelReindex); err != nil {
 		if err == store.ErrNotFound {
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 	return ErrBackfillRunning
 }


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=37b70cb6415643e29d93132be66b1804)

Add version 2 to indexer config. 

- counts in `validator_summary` table are not correct, fixed [here](https://github.com/figment-networks/polkadothub-indexer/pull/13)
we need to reindex `validator_session_sequences` to recreate summary data (old seqs are purged). We don't need to reindex `validator_era_sequences` since the data is fine and is never purged


- uptime counts in `validator_aggregate` table are also off, fixed [here](https://github.com/figment-networks/polkadothub-indexer/pull/9)

```
defaultdb=> select count(1) from validator_aggregates where accumulated_uptime_count > 1;
 count
-------
     0
(1 row)
```

