### PR TITLE
Don't update display_name to empty string

### DIFF
--- a/indexer_config.json
+++ b/indexer_config.json
@@ -9,6 +9,11 @@
           "id": 2,
           "targets": [2,4],
           "parallel": true
+      },
+      {
+          "id": 3,
+          "targets": [4],
+          "parallel": true
       }
     ],
     "shared_tasks": [

--- a/model/validator_agg.go
+++ b/model/validator_agg.go
@@ -28,8 +28,11 @@ func (s *ValidatorAgg) Equal(m ValidatorAgg) bool {
 func (s *ValidatorAgg) Update(u *ValidatorAgg) {
 	s.Aggregate.RecentAtHeight = u.Aggregate.RecentAtHeight
 	s.Aggregate.RecentAt = u.Aggregate.RecentAt
-	s.DisplayName = u.DisplayName
 	s.RecentAsValidatorHeight = u.RecentAsValidatorHeight
 	s.AccumulatedUptime = u.AccumulatedUptime
 	s.AccumulatedUptimeCount = u.AccumulatedUptimeCount
+
+	if u.DisplayName != "" {
+		s.DisplayName = u.DisplayName
+	}
 }


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=5f5352157bee458698749e63ba6f5c35)


Issue is that we update validator aggs based on `ParsedValidatorsData`. `ParsedValidatorsData` is comprised of `rawStakingState.GetValidators()` (where display name is) and `rawValidatorPerformances` and it's possible for there to be values in the latter and not the former. When that's the case, the we don't want to update the display_name since there is no value.
