### PR TITLE
Order by height ASC

### DIFF
--- a/store/psql/syncables_store.go
+++ b/store/psql/syncables_store.go
@@ -57,7 +57,7 @@ func (s SyncablesStore) FindLastInSessionForHeight(height int64) (syncable *mode
 
 	err = s.db.
 		Where("height >= ? AND last_in_session = ?", height, true).
-		Order("height DESC").
+		Order("height ASC").
 		First(result).
 		Error
 


### PR DESCRIPTION
[notion](https://www.notion.so/figmentnetworks/Indexer-returns-does-not-return-staking-data-for-certain-validators-but-does-return-uptime-data-2bbe0c9e17c94002a01359f643d8e11f?d=96e1ebaa-9452-4c9c-9cd9-8fc951f7e6ed)