### PR TITLE
Don't save unclaimed rewards if rewards already exist

### DIFF
--- a/store/psql/queries/queries.go
+++ b/store/psql/queries/queries.go
@@ -34,7 +34,7 @@ const (
 	EventSeqWithTxHashForSrcAndTarget = `	SELECT 		e.height, 		e.method, 		e.section, 		e.data, 		t.hash 	FROM event_sequences AS e 	INNER JOIN transaction_sequences as t 		ON t.height = e.height AND t.index = e.extrinsic_index 	WHERE e.section = ? AND e.method = ? AND (e.data->0->>'value' = ? OR e.data->1->>'value' = ?)`
 	
 	// store/psql/queries/reward_era_seq_insert.sql
-	RewardEraSeqInsert = `INSERT INTO reward_era_sequences (   era,   start_height,   end_height,   time,   stash_account,   validator_stash_account,   amount,   kind,   claimed ) VALUES @values  ON CONFLICT (era, stash_account, validator_stash_account, kind) DO UPDATE SET   amount         = excluded.amount,   claimed        = excluded.claimed `
+	RewardEraSeqInsert = `INSERT INTO reward_era_sequences (   era,   start_height,   end_height,   time,   stash_account,   validator_stash_account,   amount,   kind,   claimed ) VALUES @values  ON CONFLICT (era, stash_account, validator_stash_account, kind) DO NOTHING; `
 	
 	// store/psql/queries/system_event_insert.sql
 	SystemEventInsert = `INSERT INTO system_events (   created_at,   updated_at,   height,   time,   actor,   kind,   data ) VALUES @values  ON CONFLICT (height, actor, kind) DO UPDATE SET   updated_at   = excluded.updated_at,   data         = excluded.data `

--- a/store/psql/queries/reward_era_seq_insert.sql
+++ b/store/psql/queries/reward_era_seq_insert.sql
@@ -11,7 +11,4 @@ INSERT INTO reward_era_sequences (
 )
 VALUES @values
 
-ON CONFLICT (era, stash_account, validator_stash_account, kind) DO UPDATE
-SET
-  amount         = excluded.amount,
-  claimed        = excluded.claimed
+ON CONFLICT (era, stash_account, validator_stash_account, kind) DO NOTHING;


### PR DESCRIPTION
Bug was the following:

if we started the indexer from era 160, and then there was a transaction to claim rewards for era 159, then we would insert the claimed rewards to the database for era 159. When the backfill process caught up to era 159, it would then also use the insert call which would update all these rewards as 'unclaimed'. 

Solution is to only insert the rewards into the db once and do nothing on conflict. Normal flow stays in tact: indexer adds unclaimed rewards for era 160 to db, a transaction to claim rewards for validator x at era 160 happens sometime afterwards and we update claimed='t' via the MarkAllClaimed() call.

