### PR TITLE
Bug fix/rewards err

### DIFF
--- a/indexer/logger.go
+++ b/indexer/logger.go
@@ -3,13 +3,14 @@ package indexer
 import (
 	"github.com/figment-networks/indexing-engine/pipeline"
 	"github.com/figment-networks/polkadothub-indexer/utils/logger"
+	"go.uber.org/zap"
 )
 
 func NewLogger() pipeline.Logger {
 	return &idxLogger{}
 }
 
-type idxLogger struct {}
+type idxLogger struct{}
 
 func (l idxLogger) Info(msg string) {
 	logger.Info(msg)
@@ -17,4 +18,8 @@ func (l idxLogger) Info(msg string) {
 
 func (l idxLogger) Debug(msg string) {
 	logger.Debug(msg)
+}
+
+func (l idxLogger) Error(err error, tags ...zap.Field) {
+	logger.Error(err, tags...)
 }

--- a/indexer/parser_tasks.go
+++ b/indexer/parser_tasks.go
@@ -132,7 +132,7 @@ func (t *validatorsParserTask) Run(ctx context.Context, p pipeline.Payload) erro
 
 	var err error
 	var c RewardsCalculator
-	if payload.RawStaking.GetTotalRewardPoints() != 0 && payload.RawStaking.GetTotalRewardPayout() != "" {
+	if payload.RawStaking.GetTotalRewardPoints() != 0 && payload.RawStaking.GetTotalRewardPayout() != "0" {
 		c, err = newRewardsCalulator(payload.RawStaking.GetTotalRewardPoints(), payload.RawStaking.GetTotalRewardPayout())
 		if err != nil {
 			return err

--- a/indexer/parser_tasks_test.go
+++ b/indexer/parser_tasks_test.go
@@ -206,7 +206,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 				},
 			},
 			totalRewardPoints: 100,
-			totalRewardPayout: "",
+			totalRewardPayout: "0",
 		},
 		{description: "Creates staker rewards if commission is 100%",
 			rawValidator: &stakingpb.Validator{

--- a/indexer/sequencer_tasks.go
+++ b/indexer/sequencer_tasks.go
@@ -13,7 +13,6 @@ import (
 	"github.com/figment-networks/polkadothub-indexer/metric"
 	"github.com/figment-networks/polkadothub-indexer/model"
 	"github.com/figment-networks/polkadothub-indexer/store"
-	"github.com/figment-networks/polkadothub-indexer/types"
 	"github.com/figment-networks/polkadothub-indexer/utils/logger"
 	"github.com/figment-networks/polkadothub-proxy/grpc/event/eventpb"
 )
@@ -461,7 +460,17 @@ func (t *rewardEraSeqCreatorTask) Run(ctx context.Context, p pipeline.Payload) e
 			}
 		}
 
-		rewards, rewardclaims, err := t.getRewardsFromEvents(tx.GetExtrinsicIndex(), claims, payload.RawEvents)
+		if len(claims) == 0 {
+			continue
+		}
+
+		legitimateClaims, rewardArgs, err := t.getLegitimateClaimsAndRewardArgs(claims, payload.RawEvents, tx.GetExtrinsicIndex())
+		if err != nil {
+			// TODO impossible to extract rewards for this claim
+			continue
+		}
+
+		rewards, rewardclaims, err := t.extractRewards(legitimateClaims, rewardArgs)
 		if err != nil {
 			return err
 		}
@@ -501,13 +510,65 @@ func (t *rewardEraSeqCreatorTask) getEraSeq(era int64, currentSyncable *model.Sy
 	}, nil
 }
 
-// getRewardsFromEvents rreturns claims if rewards exist already in db, and returns new reward seqs if reward seqs don't exist in db
-func (t *rewardEraSeqCreatorTask) getRewardsFromEvents(txIdx int64, claims []RewardsClaim, events []*eventpb.Event) ([]model.RewardEraSeq, []RewardsClaim, error) {
+// getLegitimateClaimsAndRewardArgs filters claims that are either:
+// a) not from an era validator
+// b) have no reward events associated with claim (this happens when rewards have already been claimed for this validator and era)
+func (t *rewardEraSeqCreatorTask) getLegitimateClaimsAndRewardArgs(claims []RewardsClaim, events []*eventpb.Event, txIdx int64) ([]RewardsClaim, []rewardEventArgs, error) {
+	var legitimate []RewardsClaim
+	var args []rewardEventArgs
+
+	validatorClaimMap := make(map[string]int)
+	for _, c := range claims {
+		// must be an era validator to claim rewards
+		_, err := t.validatorDb.FindByEraAndStashAccount(c.Era, c.ValidatorStash)
+		if err == store.ErrNotFound {
+			continue
+		} else if err != nil {
+			return legitimate, args, err
+		}
+		validatorClaimMap[c.ValidatorStash]++
+	}
+
+	validatorHasEvent := make(map[string]int)
+	for _, ev := range events {
+		if ev.GetExtrinsicIndex() != txIdx || ev.GetMethod() != eventMethodReward || ev.GetSection() != sectionStaking {
+			continue
+		}
+
+		arg, err := t.getRewardEventArgsFromData(ev)
+		if err != nil {
+			return legitimate, args, err
+		}
+
+		if _, ok := validatorClaimMap[arg.stash]; ok {
+			validatorHasEvent[arg.stash]++
+		}
+		args = append(args, arg)
+	}
+
+	for _, c := range claims {
+		eventcount, ok := validatorHasEvent[c.ValidatorStash]
+		if !ok {
+			continue
+		}
+		claimcount, _ := validatorClaimMap[c.ValidatorStash]
+		if claimcount != eventcount {
+			return legitimate, args, fmt.Errorf("cannot determine legitimate claim for validator %v", c.ValidatorStash)
+		}
+
+		legitimate = append(legitimate, c)
+	}
+
+	return legitimate, args, nil
+}
+
+// extractRewards rreturns claims if rewards exist already in db, and returns new reward seqs if reward seqs don't exist in db
+func (t *rewardEraSeqCreatorTask) extractRewards(claims []RewardsClaim, rewardArgs []rewardEventArgs) ([]model.RewardEraSeq, []RewardsClaim, error) {
 	var rewards []model.RewardEraSeq
 	var rewardClaims []RewardsClaim
 
-	if len(events) == 0 && len(claims) != 0 {
-		return rewards, rewardClaims, fmt.Errorf("[getRewardsFromEvents] expected events to not be empty")
+	if len(rewardArgs) == 0 && len(claims) != 0 {
+		return rewards, rewardClaims, fmt.Errorf("[extractRewards] expected rewardArgs to not be empty")
 	}
 
 	var idx int
@@ -524,7 +585,7 @@ func (t *rewardEraSeqCreatorTask) getRewardsFromEvents(txIdx int64, claims []Rew
 			return rewards, rewardClaims, err
 		}
 
-		extractedRewards, ranged, err := t.extractRewardsForClaimFromEvents(claim, eraSeq, txIdx, nextVald, events[idx:])
+		extractedRewards, ranged, err := t.extractRewardsForClaimFromRewardEventArgs(claim, eraSeq, nextVald, rewardArgs[idx:])
 		if err != nil {
 			return rewards, rewardClaims, err
 		}
@@ -553,39 +614,30 @@ func (t *rewardEraSeqCreatorTask) getRewardsFromEvents(txIdx int64, claims []Rew
 	return rewards, rewardClaims, nil
 }
 
-func (t *rewardEraSeqCreatorTask) extractRewardsForClaimFromEvents(claim RewardsClaim, eraSeq model.EraSequence, txIdx int64, nextVald string, events []*eventpb.Event) ([]model.RewardEraSeq, int, error) {
+func (t *rewardEraSeqCreatorTask) extractRewardsForClaimFromRewardEventArgs(claim RewardsClaim, eraSeq model.EraSequence, nextVald string, rewardArgs []rewardEventArgs) ([]model.RewardEraSeq, int, error) {
 	var rewards []model.RewardEraSeq
 	var foundCurrVald bool
 
-	for i, event := range events {
-		if event.GetExtrinsicIndex() != txIdx || event.GetMethod() != eventMethodReward || event.GetSection() != sectionStaking {
-			continue
-		}
-
-		stash, amount, err := t.getStashAndAmountFromData(event)
-		if err != nil {
-			return rewards, i, err
-		}
-
-		if foundCurrVald && stash == nextVald {
+	for i, arg := range rewardArgs {
+		if foundCurrVald && arg.stash == nextVald {
 			return rewards, i, nil
 		}
 
-		if stash == claim.ValidatorStash {
+		if arg.stash == claim.ValidatorStash {
 			foundCurrVald = true
 		}
 
 		reward := model.RewardEraSeq{
 			Kind:                  model.RewardReward,
 			EraSequence:           &eraSeq,
-			StashAccount:          stash,
-			Amount:                amount.String(),
+			StashAccount:          arg.stash,
+			Amount:                arg.amount,
 			ValidatorStashAccount: claim.ValidatorStash,
 			Claimed:               true,
 			TxHash:                claim.TxHash,
 		}
 
-		if stash == claim.ValidatorStash {
+		if arg.stash == claim.ValidatorStash {
 			reward.Kind = model.RewardCommissionAndReward
 		}
 
@@ -599,16 +651,21 @@ func (t *rewardEraSeqCreatorTask) extractRewardsForClaimFromEvents(claim Rewards
 	return rewards, 0, nil
 }
 
-func (t *rewardEraSeqCreatorTask) getStashAndAmountFromData(event *eventpb.Event) (stash string, amount types.Quantity, err error) {
+type rewardEventArgs struct {
+	stash  string
+	amount string
+}
+
+func (t *rewardEraSeqCreatorTask) getRewardEventArgsFromData(event *eventpb.Event) (args rewardEventArgs, err error) {
 	for _, d := range event.GetData() {
 		switch d.GetName() {
 		case accountKey:
-			stash = d.Value
+			args.stash = d.Value
 		case balanceKey:
-			amount, err = types.NewQuantityFromString(d.Value)
+			args.amount = d.Value
 		}
 	}
-	if stash == "" {
+	if args.stash == "" {
 		err = errUnexpectedEventDataFormat
 	}
 	return

--- a/indexer/sequencer_tasks_test.go
+++ b/indexer/sequencer_tasks_test.go
@@ -347,6 +347,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 
 			rewardsMock := mock.NewMockRewards(ctrl)
 			rewardsMock.EXPECT().GetCount(gomock.Any(), gomock.Any()).Return(int64(1), nil).AnyTimes()
+			rewardsMock.EXPECT().GetByStashAndEra(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.RewardEraSeq{}, nil).AnyTimes()
 
 			syncablesMock := mock.NewMockSyncables(ctrl)
 			syncablesMock.EXPECT().FindLastInEra(gomock.Any()).Return(&model.Syncable{}, nil).AnyTimes()

--- a/indexer/sequencer_tasks_test.go
+++ b/indexer/sequencer_tasks_test.go
@@ -212,7 +212,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 	}{
 		{
 			description: "expect claims if there's a payout stakers transaction",
-			txs:         []*transactionpb.Transaction{testPayoutStakersTx("v1", 182, "abc")},
+			txs:         []*transactionpb.Transaction{testPayoutStakersTx("v1", 182, "abc", 0)},
 			events: []*eventpb.Event{
 				testpbRewardEvent(0, "v1", "1000"),
 			},
@@ -220,7 +220,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		},
 		{
 			description: "expect claims if there's multiple payout stakers transaction",
-			txs:         []*transactionpb.Transaction{testPayoutStakersTx("v1", 182, "abc"), testPayoutStakersTx("v1", 180, "d"), testPayoutStakersTx("v2", 180, "e")},
+			txs:         []*transactionpb.Transaction{testPayoutStakersTx("v1", 182, "abc", 0), testPayoutStakersTx("v1", 180, "d", 1), testPayoutStakersTx("v2", 180, "e", 2)},
 			events: []*eventpb.Event{
 				testpbRewardEvent(0, "v1", "1000"),
 				testpbRewardEvent(1, "v1", "2000"),
@@ -230,7 +230,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		},
 		{
 			description: "expect claims only for payout stakers tx",
-			txs:         []*transactionpb.Transaction{{Section: "staking", Method: "Foo", IsSuccess: true, Hash: "foo"}, testPayoutStakersTx("v1", 180, "abc")},
+			txs:         []*transactionpb.Transaction{{Section: "staking", Method: "Foo", IsSuccess: true, Hash: "foo"}, testPayoutStakersTx("v1", 180, "abc", 1)},
 			events: []*eventpb.Event{
 				testpbRewardEvent(1, "v1", "2000"),
 			},
@@ -239,7 +239,9 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		{
 			description: "expect claims if there's a utility batch transaction containing payout stakers txs",
 			txs: []*transactionpb.Transaction{
-				{Method: "batch", Section: "utility",
+				{
+					Method: "batch", Section: "utility",
+					ExtrinsicIndex: 0,
 					CallArgs: []*transactionpb.CallArg{
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","199"]`},
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","202"]`},
@@ -259,7 +261,9 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		{
 			description: "expect claims if there's a utility batchAll transaction containing payout stakers txs",
 			txs: []*transactionpb.Transaction{
-				{Method: "batchAll", Section: "utility",
+				{
+					Method: "batchAll", Section: "utility",
+					ExtrinsicIndex: 0,
 					CallArgs: []*transactionpb.CallArg{
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","199"]`},
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","202"]`},
@@ -279,7 +283,9 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		{
 			description: "expect claims if there's a proxy proxy transaction containing payout stakers txs",
 			txs: []*transactionpb.Transaction{
-				{Method: "proxy", Section: "proxy",
+				{
+					Method: "proxy", Section: "proxy",
+					ExtrinsicIndex: 0,
 					CallArgs: []*transactionpb.CallArg{
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","199"]`},
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","202"]`},
@@ -298,7 +304,9 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		{
 			description: "does not expect claims if tx is not a success",
 			txs: []*transactionpb.Transaction{
-				{Method: "batchAll", Section: "utility",
+				{
+					Method: "batchAll", Section: "utility",
+					ExtrinsicIndex: 0,
 					CallArgs: []*transactionpb.CallArg{
 						{Method: "payoutStakers", Section: "staking", Value: `["v1","199"]`},
 					},
@@ -313,7 +321,9 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 		{
 			description: "expect error if there's a batch transaction with call args in unknown format",
 			txs: []*transactionpb.Transaction{
-				{Method: "batchAll", Section: "utility",
+				{
+					Method: "batchAll", Section: "utility",
+					ExtrinsicIndex: 0,
 					CallArgs: []*transactionpb.CallArg{
 						{Method: "payoutStakers", Section: "staking", Value: `[validatorId: "v1", era: "199"]`},
 					},
@@ -341,7 +351,10 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 			syncablesMock := mock.NewMockSyncables(ctrl)
 			syncablesMock.EXPECT().FindLastInEra(gomock.Any()).Return(&model.Syncable{}, nil).AnyTimes()
 
-			task := NewRewardEraSeqCreatorTask(nil, rewardsMock, syncablesMock, nil)
+			validatorMock := mock.NewMockValidatorEraSeq(ctrl)
+			validatorMock.EXPECT().FindByEraAndStashAccount(gomock.Any(), gomock.Any()).Return(&model.ValidatorEraSeq{}, nil).AnyTimes()
+
+			task := NewRewardEraSeqCreatorTask(nil, rewardsMock, syncablesMock, validatorMock)
 
 			pl := &payload{
 				Syncable: &model.Syncable{Era: currEra},
@@ -377,30 +390,28 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 	}
 }
 
-func Test_addRewardsFromEvents(t *testing.T) {
+func Test_extractRewards(t *testing.T) {
 	tests := []struct {
 		description    string
 		txIdx          int64
 		rawClaimsForTx []RewardsClaim
-		events         []*eventpb.Event
+		rewardArgs     []rewardEventArgs
 		expectRewards  []model.RewardEraSeq
 		expectErr      bool
 	}{
 		{
 			description:    "expect no rewards if there's no claims",
 			rawClaimsForTx: []RewardsClaim{},
-			events:         []*eventpb.Event{},
 		},
 		{
-			description:    "expect error if there's a claim and no events",
+			description:    "expect error if there's a claim and no rewardArgs",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
-			events:         []*eventpb.Event{},
 			expectErr:      true,
 		},
 		{
-			description:    "expect validator and nominator rewards if there are reward events",
+			description:    "expect validator and nominator rewards if there are rewardArgs",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
-			events:         []*eventpb.Event{testpbRewardEvent(0, "v1", "1500"), testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			rewardArgs:     []rewardEventArgs{{"v1", "1500"}, {"nom1", "1000"}, {"nom2", "2000"}},
 			expectRewards: []model.RewardEraSeq{
 				{
 					EraSequence:           &model.EraSequence{Era: 100},
@@ -432,79 +443,15 @@ func Test_addRewardsFromEvents(t *testing.T) {
 			},
 		},
 		{
-			description:    "expect no rewards  from non-reward events",
-			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
-			events: []*eventpb.Event{
-				{Section: sectionStaking, Method: "Foo"},
-				testpbRewardEvent(0, "v1", "1500"),
-				testpbRewardEvent(0, "nom1", "1000"),
-				{Section: "Foo", Method: "Foo"},
-			},
-			expectRewards: []model.RewardEraSeq{
-				{
-					EraSequence:           &model.EraSequence{Era: 100},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "v1",
-					Kind:                  model.RewardCommissionAndReward,
-					Amount:                "1500",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-				{
-					EraSequence:           &model.EraSequence{Era: 100},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "nom1",
-					Kind:                  model.RewardReward,
-					Amount:                "1000",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-			},
-		},
-		{
-			description:    "expect rewards only from events from same transaction",
-			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
-			txIdx:          1,
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v0", "2000"),
-				testpbRewardEvent(0, "nom1", "2000"),
-				testpbRewardEvent(1, "v1", "1500"),
-				testpbRewardEvent(1, "nom1", "1000"),
-				testpbRewardEvent(2, "v1", "5000"),
-				testpbRewardEvent(2, "nom1", "5000"),
-				{ExtrinsicIndex: 2, Section: "Foo", Method: "Foo"},
-			},
-			expectRewards: []model.RewardEraSeq{
-				{
-					EraSequence:           &model.EraSequence{Era: 100},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "v1",
-					Kind:                  model.RewardCommissionAndReward,
-					Amount:                "1500",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-				{
-					EraSequence:           &model.EraSequence{Era: 100},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "nom1",
-					Kind:                  model.RewardReward,
-					Amount:                "1000",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-			},
-		},
-		{
 			description:    "expect rewards to be created for multiple claims",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}, {102, "v1", "abc"}},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v1", "1000"),
-				testpbRewardEvent(0, "nom1", "1500"),
-				testpbRewardEvent(0, "v1", "2000"),
-				testpbRewardEvent(0, "nom1", "2500"),
-				testpbRewardEvent(0, "v1", "3000"),
-				testpbRewardEvent(0, "nom1", "3500"),
+			rewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"nom1", "1500"},
+				{"v1", "2000"},
+				{"nom1", "2500"},
+				{"v1", "3000"},
+				{"nom1", "3500"},
 			},
 			expectRewards: []model.RewardEraSeq{
 				{
@@ -566,11 +513,11 @@ func Test_addRewardsFromEvents(t *testing.T) {
 		{
 			description:    "expect validator rewards to be created for multiple claims",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}, {102, "v2", "abc"}, {102, "v1", "abc"}},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v1", "1000"),
-				testpbRewardEvent(0, "v1", "2000"),
-				testpbRewardEvent(0, "v2", "3000"),
-				testpbRewardEvent(0, "v1", "4000"),
+			rewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"v1", "2000"},
+				{"v2", "3000"},
+				{"v1", "4000"},
 			},
 			expectRewards: []model.RewardEraSeq{
 				{
@@ -612,83 +559,29 @@ func Test_addRewardsFromEvents(t *testing.T) {
 			},
 		},
 		{
-			description:    "expect validator rewards to be created for multiple claims when there's non reward events",
-			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}, {102, "v2", "abc"}, {102, "v1", "abc"}},
-			events: []*eventpb.Event{
-				{Section: "Foo", Method: "Foo"},
-				testpbRewardEvent(0, "v1", "1000"),
-				{Section: "Foo", Method: "Foo"},
-				{Section: "Foo", Method: "Foo"},
-				testpbRewardEvent(0, "v1", "2000"),
-				{Section: "Foo", Method: "Foo"},
-				testpbRewardEvent(0, "v2", "3000"),
-				{Section: "Foo", Method: "Foo"},
-				testpbRewardEvent(0, "v1", "4000"),
-				{Section: "Foo", Method: "Foo"},
-			},
-			expectRewards: []model.RewardEraSeq{
-				{
-					EraSequence:           &model.EraSequence{Era: 100},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "v1",
-					Kind:                  model.RewardCommissionAndReward,
-					Amount:                "1000",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-				{
-					EraSequence:           &model.EraSequence{Era: 101},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "v1",
-					Kind:                  model.RewardCommissionAndReward,
-					Amount:                "2000",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-				{
-					EraSequence:           &model.EraSequence{Era: 102},
-					ValidatorStashAccount: "v2",
-					StashAccount:          "v2",
-					Kind:                  model.RewardCommissionAndReward,
-					Amount:                "3000",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-				{
-					EraSequence:           &model.EraSequence{Era: 102},
-					ValidatorStashAccount: "v1",
-					StashAccount:          "v1",
-					Kind:                  model.RewardCommissionAndReward,
-					Amount:                "4000",
-					Claimed:               true,
-					TxHash:                "abc",
-				},
-			},
-		},
-		{
-			description:    "expect error if event for validator is missing from raw events (all same)",
+			description:    "expect error if event for validator is missing from rewardArgs (all same)",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}, {102, "v1", "abc"}, {103, "v1", "abc"}},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v1", "1000"),
-				testpbRewardEvent(0, "v1", "2000"),
-				testpbRewardEvent(0, "v1", "4000"),
+			rewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"v1", "2000"},
+				{"v1", "4000"},
 			},
 			expectErr: true,
 		},
 		{
-			description:    "expect error if event for validator is missing from raw events (one different)",
+			description:    "expect error if event for validator is missing from rewardArgs (one different)",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}, {102, "v2", "abc"}, {103, "v1", "abc"}},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v1", "1000"),
-				testpbRewardEvent(0, "v1", "2000"),
-				testpbRewardEvent(0, "v1", "4000"),
+			rewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"v1", "2000"},
+				{"v1", "4000"},
 			},
 			expectErr: true,
 		},
 		{
-			description:    "expect nominator rewards if  event for validator is missing from raw events but there's only one claim",
+			description:    "expect nominator rewards if  event for validator is missing from raw rewardArgs but there's only one claim",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
-			events:         []*eventpb.Event{testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			rewardArgs:     []rewardEventArgs{{"nom1", "1000"}, {"nom2", "2000"}},
 			expectRewards: []model.RewardEraSeq{
 				{
 					EraSequence:           &model.EraSequence{Era: 100},
@@ -711,24 +604,24 @@ func Test_addRewardsFromEvents(t *testing.T) {
 			},
 		},
 		{
-			description:    "expect error if raw events are in reverse order",
+			description:    "expect error if raw rewardArgs are in reverse order",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v2", "d"}, {102, "v3", "e"}},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v3", "1000"),
-				testpbRewardEvent(0, "v2", "2000"),
-				testpbRewardEvent(0, "v1", "4000"),
+			rewardArgs: []rewardEventArgs{
+				{"v3", "1000"},
+				{"v2", "2000"},
+				{"v1", "4000"},
 			},
 			expectErr: true,
 		},
 		{
-			description:    "expect error events are in scrambled order",
+			description:    "expect error rewardArgs are in scrambled order",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v2", "abc"}, {102, "v3", "abc"}, {102, "v4", "abc"}, {102, "v5", "abc"}},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v1", "1000"),
-				testpbRewardEvent(0, "v3", "2000"),
-				testpbRewardEvent(0, "v2", "4000"),
-				testpbRewardEvent(0, "v4", "2000"),
-				testpbRewardEvent(0, "v5", "2000"),
+			rewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"v3", "2000"},
+				{"v2", "4000"},
+				{"v4", "2000"},
+				{"v5", "2000"},
 			},
 			expectErr: true,
 		},
@@ -753,7 +646,7 @@ func Test_addRewardsFromEvents(t *testing.T) {
 
 			task := NewRewardEraSeqCreatorTask(nil, rewardsMock, syncablesMock, validatorMock)
 
-			rewards, claims, err := task.getRewardsFromEvents(tt.txIdx, tt.rawClaimsForTx, tt.events)
+			rewards, claims, err := task.extractRewards(tt.rawClaimsForTx, tt.rewardArgs)
 			if tt.expectErr {
 				if err == nil {
 					t.Errorf("Expected run error; got nil")
@@ -804,7 +697,7 @@ func Test_addRewardsFromEvents(t *testing.T) {
 		rawClaimsForTx      []RewardsClaim
 		returnCountForClaim map[RewardsClaim]int64
 		returnValidatorSeq  *model.ValidatorEraSeq
-		events              []*eventpb.Event
+		rewardArgs          []rewardEventArgs
 		expectRewards       []model.RewardEraSeq
 		expectClaimed       []RewardsClaim
 		expectErr           bool
@@ -813,13 +706,13 @@ func Test_addRewardsFromEvents(t *testing.T) {
 			description:         "expect claim only for rewards that exist in db",
 			rawClaimsForTx:      []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}, {102, "v1", "abc"}},
 			returnCountForClaim: map[RewardsClaim]int64{{100, "v1", "abc"}: 0, {101, "v1", "abc"}: 2, {102, "v1", "abc"}: 0},
-			events: []*eventpb.Event{
-				testpbRewardEvent(0, "v1", "1000"),
-				testpbRewardEvent(0, "nom1", "1500"),
-				testpbRewardEvent(0, "v1", "2000"),
-				testpbRewardEvent(0, "nom1", "2500"),
-				testpbRewardEvent(0, "v1", "3000"),
-				testpbRewardEvent(0, "nom1", "3500"),
+			rewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"nom1", "1500"},
+				{"v1", "2000"},
+				{"nom1", "2500"},
+				{"v1", "3000"},
+				{"nom1", "3500"},
 			},
 			expectClaimed: []RewardsClaim{{101, "v1", "abc"}},
 			expectRewards: []model.RewardEraSeq{
@@ -861,28 +754,28 @@ func Test_addRewardsFromEvents(t *testing.T) {
 			description:         "expect error if rewards count < len(rewards)",
 			rawClaimsForTx:      []RewardsClaim{{100, "v1", "abc"}},
 			returnCountForClaim: map[RewardsClaim]int64{{100, "v1", "abc"}: 1},
-			events:              []*eventpb.Event{testpbRewardEvent(0, "v1", "1500"), testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			rewardArgs:          []rewardEventArgs{{"v1", "1500"}, {"nom1", "1000"}, {"nom2", "2000"}},
 			expectErr:           true,
 		},
 		{
 			description:         "expect error if rewards count > len(rewards)+2",
 			rawClaimsForTx:      []RewardsClaim{{100, "v1", "abc"}},
 			returnCountForClaim: map[RewardsClaim]int64{{100, "v1", "abc"}: 5},
-			events:              []*eventpb.Event{testpbRewardEvent(0, "v1", "1500"), testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			rewardArgs:          []rewardEventArgs{{"v1", "1500"}, {"nom1", "1000"}, {"nom2", "2000"}},
 			expectErr:           true,
 		},
 		{
 			description:         "expect claim if rewards count == len(rewards)",
 			rawClaimsForTx:      []RewardsClaim{{100, "v1", "abc"}},
 			returnCountForClaim: map[RewardsClaim]int64{{100, "v1", "abc"}: 3},
-			events:              []*eventpb.Event{testpbRewardEvent(0, "v1", "1500"), testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			rewardArgs:          []rewardEventArgs{{"v1", "1500"}, {"nom1", "1000"}, {"nom2", "2000"}},
 			expectClaimed:       []RewardsClaim{{100, "v1", "abc"}},
 		},
 		{
 			description:         "expect claim if rewards count == len(rewards)+1",
 			rawClaimsForTx:      []RewardsClaim{{100, "v1", "abc"}},
 			returnCountForClaim: map[RewardsClaim]int64{{100, "v1", "abc"}: 4},
-			events:              []*eventpb.Event{testpbRewardEvent(0, "v1", "1500"), testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			rewardArgs:          []rewardEventArgs{{"v1", "1500"}, {"nom1", "1000"}, {"nom2", "2000"}},
 			expectClaimed:       []RewardsClaim{{100, "v1", "abc"}},
 		},
 	}
@@ -910,7 +803,7 @@ func Test_addRewardsFromEvents(t *testing.T) {
 
 			task := NewRewardEraSeqCreatorTask(nil, rewardsMock, syncablesMock, validatorMock)
 
-			rewards, claims, err := task.getRewardsFromEvents(0, tt.rawClaimsForTx, tt.events)
+			rewards, claims, err := task.extractRewards(tt.rawClaimsForTx, tt.rewardArgs)
 			if tt.expectErr {
 				if err == nil {
 					t.Errorf("Expected run error; got nil")
@@ -946,9 +839,8 @@ func Test_addRewardsFromEvents(t *testing.T) {
 	dbErr := errors.New("dbErr")
 	testDbErrs := []struct {
 		description          string
-		txIdx                int64
 		rawClaimsForTx       []RewardsClaim
-		events               []*eventpb.Event
+		rewardArgs           []rewardEventArgs
 		returnRewardsDbErr   error
 		returnSyncablesDbErr error
 		expectErr            error
@@ -956,19 +848,19 @@ func Test_addRewardsFromEvents(t *testing.T) {
 		{
 			description:    "expect no error when db returns no error",
 			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
-			events:         []*eventpb.Event{testpbRewardEvent(0, "v1", "1500")},
+			rewardArgs:     []rewardEventArgs{{"v1", "1500"}},
 		},
 		{
 			description:        "expect error when rewards db returns error",
 			rawClaimsForTx:     []RewardsClaim{{100, "v1", "abc"}},
-			events:             []*eventpb.Event{testpbRewardEvent(0, "v1", "1500")},
+			rewardArgs:         []rewardEventArgs{{"v1", "1500"}},
 			returnRewardsDbErr: dbErr,
 			expectErr:          dbErr,
 		},
 		{
 			description:          "expect error when syncables db returns error",
 			rawClaimsForTx:       []RewardsClaim{{100, "v1", "abc"}},
-			events:               []*eventpb.Event{testpbRewardEvent(0, "v1", "1500")},
+			rewardArgs:           []rewardEventArgs{{"v1", "1500"}},
 			returnSyncablesDbErr: dbErr,
 			expectErr:            dbErr,
 		},
@@ -989,7 +881,7 @@ func Test_addRewardsFromEvents(t *testing.T) {
 
 			task := NewRewardEraSeqCreatorTask(nil, rewardsMock, syncablesMock, validatorMock)
 
-			_, _, err := task.getRewardsFromEvents(tt.txIdx, tt.rawClaimsForTx, tt.events)
+			_, _, err := task.extractRewards(tt.rawClaimsForTx, tt.rewardArgs)
 			if err != tt.expectErr {
 				t.Errorf("Unexpected error on run; got %v, want: %v", err, tt.expectErr)
 				return
@@ -999,16 +891,196 @@ func Test_addRewardsFromEvents(t *testing.T) {
 	}
 }
 
+func Test_getLegitimateClaimsAndRewardArgs(t *testing.T) {
+	tests := []struct {
+		description      string
+		txIdx            int64
+		rawClaimsForTx   []RewardsClaim
+		events           []*eventpb.Event
+		expectRewardArgs []rewardEventArgs
+		expectClaims     []RewardsClaim
+		expectErr        bool
+	}{
+		{
+			description:    "expect no results if there's no claims",
+			rawClaimsForTx: []RewardsClaim{},
+			events:         []*eventpb.Event{},
+		},
+		{
+			description:    "expect no claims or reward args if there's no reward events",
+			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
+			events:         []*eventpb.Event{{Section: sectionStaking, Method: "Foo"}},
+		},
+		{
+			description:      "expect validator and nominator rewardargs if there are reward events",
+			rawClaimsForTx:   []RewardsClaim{{100, "v1", "abc"}},
+			events:           []*eventpb.Event{testpbRewardEvent(0, "v1", "1500"), testpbRewardEvent(0, "nom1", "1000"), testpbRewardEvent(0, "nom2", "2000")},
+			expectRewardArgs: []rewardEventArgs{{"v1", "1500"}, {"nom1", "1000"}, {"nom2", "2000"}},
+			expectClaims:     []RewardsClaim{{100, "v1", "abc"}},
+		},
+		{
+			description:    "expect no rewardargs  from non-reward events",
+			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
+			events: []*eventpb.Event{
+				{Section: sectionStaking, Method: "Foo"},
+				testpbRewardEvent(0, "v1", "1500"),
+				testpbRewardEvent(0, "nom1", "1000"),
+				{Section: "Foo", Method: "Foo"},
+			},
+			expectClaims: []RewardsClaim{{100, "v1", "abc"}},
+			expectRewardArgs: []rewardEventArgs{
+				{"v1", "1500"},
+				{"nom1", "1000"},
+			},
+		},
+		{
+			description:    "expect rewardargs only from events from same transaction",
+			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}},
+			txIdx:          1,
+			events: []*eventpb.Event{
+				testpbRewardEvent(0, "v0", "2000"),
+				testpbRewardEvent(0, "nom1", "2000"),
+				testpbRewardEvent(1, "v1", "1500"),
+				testpbRewardEvent(1, "nom1", "1000"),
+				testpbRewardEvent(2, "v1", "5000"),
+				testpbRewardEvent(2, "nom1", "5000"),
+				{ExtrinsicIndex: 2, Section: "Foo", Method: "Foo"},
+			},
+			expectClaims: []RewardsClaim{{100, "v1", "abc"}},
+			expectRewardArgs: []rewardEventArgs{
+				{"v1", "1500"},
+				{"nom1", "1000"},
+			},
+		},
+		{
+			description:    "expect reward args to be created for multiple claims",
+			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v2", "abc"}, {102, "v3", "abc"}},
+			events: []*eventpb.Event{
+				testpbRewardEvent(0, "v1", "1000"),
+				testpbRewardEvent(0, "nom1", "1500"),
+				testpbRewardEvent(0, "v2", "2000"),
+				testpbRewardEvent(0, "nom1", "2500"),
+				testpbRewardEvent(0, "v3", "3000"),
+				testpbRewardEvent(0, "nom1", "3500"),
+			},
+			expectClaims: []RewardsClaim{{100, "v1", "abc"}, {101, "v2", "abc"}, {102, "v3", "abc"}},
+			expectRewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"nom1", "1500"},
+				{"v2", "2000"},
+				{"nom1", "2500"},
+				{"v3", "3000"},
+				{"nom1", "3500"},
+			},
+		},
+		{
+			description:    "expect reward args to be created for multiple claims when same validator is in list",
+			rawClaimsForTx: []RewardsClaim{{100, "v3", "abc"}, {101, "v1", "abc"}, {102, "v2", "abc"}, {102, "v1", "abc"}},
+			events: []*eventpb.Event{
+				{Section: "Foo", Method: "Foo"},
+				testpbRewardEvent(0, "v3", "1000"),
+				testpbRewardEvent(0, "v1", "2000"),
+				testpbRewardEvent(0, "nom1", "1500"),
+				testpbRewardEvent(0, "v2", "3000"),
+				{Section: "Foo", Method: "Foo"},
+				testpbRewardEvent(0, "v1", "4000"),
+			},
+			expectClaims: []RewardsClaim{{100, "v3", "abc"}, {101, "v1", "abc"}, {102, "v2", "abc"}, {102, "v1", "abc"}},
+			expectRewardArgs: []rewardEventArgs{
+				{"v3", "1000"},
+				{"v1", "2000"},
+				{"nom1", "1500"},
+				{"v2", "3000"},
+				{"v1", "4000"},
+			},
+		},
+		{
+			description:    "expect claim to be filtered if no reward events exists for validator",
+			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v2", "abc"}, {102, "v1", "abc"}, {103, "v1", "abc"}},
+			events: []*eventpb.Event{
+				testpbRewardEvent(0, "v1", "1000"),
+				testpbRewardEvent(0, "v1", "2000"),
+				testpbRewardEvent(0, "v1", "4000"),
+			},
+			expectClaims: []RewardsClaim{{100, "v1", "abc"}, {102, "v1", "abc"}, {103, "v1", "abc"}},
+			expectRewardArgs: []rewardEventArgs{
+				{"v1", "1000"},
+				{"v1", "2000"},
+				{"v1", "4000"},
+			},
+		},
+		{
+			description:    "expect error if no reward events exist for a validator but there's a validator claim with events for same validator",
+			rawClaimsForTx: []RewardsClaim{{100, "v1", "abc"}, {101, "v1", "abc"}},
+			events: []*eventpb.Event{
+				testpbRewardEvent(0, "v1", "1000"),
+			},
+			expectErr: true,
+		},
+	}
+
+	// var zero int64
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			validatorMock := mock.NewMockValidatorEraSeq(ctrl)
+
+			for _, c := range tt.rawClaimsForTx {
+				validatorMock.EXPECT().FindByEraAndStashAccount(c.Era, c.ValidatorStash).Return(&model.ValidatorEraSeq{}, nil).Times(1)
+			}
+
+			task := NewRewardEraSeqCreatorTask(nil, nil, nil, validatorMock)
+
+			legitimateClaims, rewardArgs, err := task.getLegitimateClaimsAndRewardArgs(tt.rawClaimsForTx, tt.events, tt.txIdx)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected run error; got nil")
+				}
+				return
+			} else if err != nil {
+				t.Errorf("Unexpected run error; got %v", err)
+				return
+			}
+
+			if len(legitimateClaims) != len(tt.expectClaims) {
+				t.Errorf("Unexpected claims length, want: %v, got: %+v", len(tt.expectClaims), len(legitimateClaims))
+				return
+			}
+			for i, want := range tt.expectClaims {
+				got := legitimateClaims[i]
+				if got.ValidatorStash != want.ValidatorStash || got.Era != want.Era {
+					t.Errorf("Unexpected claim at index %v; want: %v, got: %+v", i, want, got)
+				}
+			}
+
+			if len(rewardArgs) != len(tt.expectRewardArgs) {
+				t.Errorf("Unexpected rewardsArgs length, want: %v, got: %+v", len(tt.expectRewardArgs), len(rewardArgs))
+				return
+			}
+			for i, want := range tt.expectRewardArgs {
+				got := rewardArgs[i]
+				if got.stash != want.stash || got.amount != want.amount {
+					t.Errorf("Unexpected rewardarg at index %v; want: %v, got: %+v", i, want, got)
+				}
+			}
+		})
+	}
+}
+
 func testpbRewardEvent(txIdx int64, stash, amount string) *eventpb.Event {
 	return &eventpb.Event{ExtrinsicIndex: txIdx, Method: "Reward", Section: "staking", Data: []*eventpb.EventData{{Name: "AccountId", Value: stash}, {Name: "Balance", Value: amount}}}
 }
 
-func testPayoutStakersTx(stash string, era int64, hash string) *transactionpb.Transaction {
+func testPayoutStakersTx(stash string, era int64, hash string, idx int64) *transactionpb.Transaction {
 	return &transactionpb.Transaction{
-		Hash:      hash,
-		Method:    txMethodPayoutStakers,
-		Section:   sectionStaking,
-		IsSuccess: true,
-		Args:      fmt.Sprintf(`["%v","%v"]`, stash, era),
+		ExtrinsicIndex: idx,
+		Hash:           hash,
+		Method:         txMethodPayoutStakers,
+		Section:        sectionStaking,
+		IsSuccess:      true,
+		Args:           fmt.Sprintf(`["%v","%v"]`, stash, era),
 	}
 }

--- a/mock/store/mocks.go
+++ b/mock/store/mocks.go
@@ -726,6 +726,21 @@ func (mr *MockRewardsMockRecorder) GetAll(arg0, arg1, arg2 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockRewards)(nil).GetAll), arg0, arg1, arg2)
 }
 
+// GetByStashAndEra mocks base method
+func (m *MockRewards) GetByStashAndEra(arg0, arg1 string, arg2 int64) (model.RewardEraSeq, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByStashAndEra", arg0, arg1, arg2)
+	ret0, _ := ret[0].(model.RewardEraSeq)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByStashAndEra indicates an expected call of GetByStashAndEra
+func (mr *MockRewardsMockRecorder) GetByStashAndEra(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByStashAndEra", reflect.TypeOf((*MockRewards)(nil).GetByStashAndEra), arg0, arg1, arg2)
+}
+
 // GetCount mocks base method
 func (m *MockRewards) GetCount(arg0 string, arg1 int64) (int64, error) {
 	m.ctrl.T.Helper()

--- a/model/report.go
+++ b/model/report.go
@@ -1,8 +1,9 @@
 package model
 
 import (
-	"github.com/figment-networks/polkadothub-indexer/types"
 	"time"
+
+	"github.com/figment-networks/polkadothub-indexer/types"
 )
 
 const (

--- a/store/psql/reward_era_seq_store.go
+++ b/store/psql/reward_era_seq_store.go
@@ -114,7 +114,7 @@ func (s *RewardEraSeqStore) GetByStashAndEra(validatorStash, stash string, era i
 	err := s.db.
 		Table(model.RewardEraSeq{}.TableName()).
 		Where("validator_stash_account = ? AND stash_account = ? AND era = ?", validatorStash, stash, era).
-		Count(&result).
+		Find(&result).
 		Error
 
 	return result, checkErr(err)

--- a/store/psql/reward_era_seq_store.go
+++ b/store/psql/reward_era_seq_store.go
@@ -107,3 +107,15 @@ func (s RewardEraSeqStore) GetCount(validatorStash string, era int64) (int64, er
 
 	return count, err
 }
+
+// GetByStashAndEra returns for given stash for validatorStash and era
+func (s *RewardEraSeqStore) GetByStashAndEra(validatorStash, stash string, era int64) (model.RewardEraSeq, error) {
+	var result model.RewardEraSeq
+	err := s.db.
+		Table(model.RewardEraSeq{}.TableName()).
+		Where("validator_stash_account = ? AND stash_account = ? AND era = ?", validatorStash, stash, era).
+		Count(&result).
+		Error
+
+	return result, checkErr(err)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -34,6 +34,7 @@ type Rewards interface {
 	MarkAllClaimed(validatorStash string, era int64, txHash string) error
 	GetAll(address string, start, end int64) ([]model.RewardEraSeq, error)
 	GetCount(validatorStash string, era int64) (int64, error)
+	GetByStashAndEra(validatorStash, stash string, era int64) (model.RewardEraSeq, error)
 }
 
 type Syncables interface {


### PR DESCRIPTION
Filters out illegitimate reward claims (ie claims not made from validators, claims already claimed, duplicate claims). This makes it easier to determine which reward events belong to which claim in bulk txs. 

Only logs error is can't determine which rewards belong to which claim. On error indexer stops pipeline completely, so let's log for now and examine error in rollbar.

[notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=b152d98534b94241b545f6384c4eadce)