### PR TITLE
Use active era for rewards calculations

### DIFF
--- a/indexer/fetcher_tasks.go
+++ b/indexer/fetcher_tasks.go
@@ -20,14 +20,16 @@ const (
 )
 
 type HeightMeta struct {
-	Height        int64
-	Time          types.Time
-	SpecVersion   string
-	ChainUID      string
-	Session       int64
-	Era           int64
-	LastInSession bool
-	LastInEra     bool
+	Height          int64
+	Time            types.Time
+	SpecVersion     string
+	ChainUID        string
+	Session         int64
+	Era             int64
+	ActiveEra       int64
+	LastInSession   bool
+	LastInEra       bool
+	LastInActiveEra bool
 }
 
 func NewFetcherTask(client FetcherClient) pipeline.Task {
@@ -74,14 +76,16 @@ func (t *FetcherTask) Run(ctx context.Context, p pipeline.Payload) error {
 
 	meta := resp.GetChain()
 	payload.HeightMeta = HeightMeta{
-		Height:        payload.CurrentHeight,
-		Time:          *types.NewTimeFromTimestamp(*meta.GetTime()),
-		ChainUID:      meta.GetChain(),
-		SpecVersion:   meta.GetSpecVersion(),
-		Session:       meta.GetSession(),
-		Era:           meta.GetEra(),
-		LastInSession: meta.GetLastInSession(),
-		LastInEra:     meta.GetLastInEra(),
+		Height:          payload.CurrentHeight,
+		Time:            *types.NewTimeFromTimestamp(*meta.GetTime()),
+		ChainUID:        meta.GetChain(),
+		SpecVersion:     meta.GetSpecVersion(),
+		Session:         meta.GetSession(),
+		Era:             meta.GetEra(),
+		ActiveEra:       meta.GetActiveEra(),
+		LastInSession:   meta.GetLastInSession(),
+		LastInEra:       meta.GetLastInEra(),
+		LastInActiveEra: meta.GetLastInActiveEra(),
 	}
 
 	return nil

--- a/indexer/parser_tasks.go
+++ b/indexer/parser_tasks.go
@@ -158,7 +158,7 @@ func (t *validatorsParserTask) Run(ctx context.Context, p pipeline.Payload) erro
 
 		if c != nil {
 			parsedRewards := t.getUnclaimedRewardData(c, rawValidatorStakingInfo)
-			parsedRewards.Era = payload.Syncable.Era
+			parsedRewards.Era = payload.HeightMeta.ActiveEra
 			parsedData.parsedRewards = parsedRewards
 		}
 		parsedValidatorsData[stashAccount] = parsedData

--- a/indexer/parser_tasks_test.go
+++ b/indexer/parser_tasks_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	mock_client "github.com/figment-networks/polkadothub-indexer/mock/client"
-	"github.com/figment-networks/polkadothub-indexer/model"
 	"github.com/figment-networks/polkadothub-proxy/grpc/account/accountpb"
 	"github.com/figment-networks/polkadothub-proxy/grpc/block/blockpb"
 	"github.com/figment-networks/polkadothub-proxy/grpc/staking/stakingpb"
@@ -166,7 +165,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 		})
 	}
 
-	var syncableEra int64 = 100
+	var activeEra int64 = 100
 	parsedUnclaimedRewardTests := []struct {
 		description            string
 		rawValidator           *stakingpb.Validator
@@ -191,7 +190,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			totalRewardPoints:      100,
 			totalRewardPayout:      "4000",
 			expectCommission:       true,
-			expectEra:              syncableEra,
+			expectEra:              activeEra,
 			expectNumStakerRewards: 2,
 		},
 		{description: "does not update ParsedRewards if there's no reward payout",
@@ -221,7 +220,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			},
 			totalRewardPoints:      100,
 			totalRewardPayout:      "4000",
-			expectEra:              syncableEra,
+			expectEra:              activeEra,
 			expectCommission:       true,
 			expectNumStakerRewards: 2,
 		},
@@ -238,7 +237,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			},
 			totalRewardPoints:      100,
 			totalRewardPayout:      "4000",
-			expectEra:              syncableEra,
+			expectEra:              activeEra,
 			expectNumStakerRewards: 2,
 		},
 		{description: "Create staker reward if reward is 0",
@@ -255,7 +254,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			totalRewardPoints:      100,
 			totalRewardPayout:      "4000",
 			expectCommission:       true,
-			expectEra:              syncableEra,
+			expectEra:              activeEra,
 			expectNumStakerRewards: 2,
 		},
 		{description: "expect validtor reward if validator is staked",
@@ -268,7 +267,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			},
 			totalRewardPoints: 100,
 			totalRewardPayout: "4000",
-			expectEra:         syncableEra,
+			expectEra:         activeEra,
 			expectCommission:  true,
 			expectReward:      true,
 		},
@@ -284,7 +283,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			},
 			totalRewardPoints: 100,
 			totalRewardPayout: "4000",
-			expectEra:         syncableEra,
+			expectEra:         activeEra,
 			expectCommission:  true,
 		},
 	}
@@ -300,7 +299,7 @@ func TestValidatorParserTask_Run(t *testing.T) {
 			task := NewValidatorsParserTask(nil, mockClient, nil, nil, nil)
 
 			pl := &payload{
-				Syncable: &model.Syncable{Era: syncableEra},
+				HeightMeta: HeightMeta{ActiveEra: activeEra},
 				RawStaking: &stakingpb.Staking{
 					TotalRewardPayout: tt.totalRewardPayout,
 					TotalRewardPoints: tt.totalRewardPoints,

--- a/indexer/sequencer_tasks_test.go
+++ b/indexer/sequencer_tasks_test.go
@@ -112,7 +112,7 @@ func TestValidatorSeqCreator_Run(t *testing.T) {
 }
 
 func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
-	const currEra int64 = 20
+	const currActiveEra int64 = 20
 	const testValidator = "testValidator"
 
 	tests := []struct {
@@ -126,7 +126,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 			validator: parsedValidator{parsedRewards: parsedRewards{
 				Commission: "300",
 				Reward:     "300",
-				Era:        currEra,
+				Era:        currActiveEra,
 			}},
 			expectedKinds: []model.RewardKind{model.RewardCommission, model.RewardReward},
 		},
@@ -134,7 +134,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 			lastInEra: true,
 			validator: parsedValidator{parsedRewards: parsedRewards{
 				RewardAndCommission: "300",
-				Era:                 currEra,
+				Era:                 currActiveEra,
 			}},
 			expectedKinds: []model.RewardKind{model.RewardCommissionAndReward},
 		},
@@ -142,21 +142,21 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 			lastInEra: true,
 			validator: parsedValidator{parsedRewards: parsedRewards{
 				StakerRewards: []stakerReward{{Stash: "AAA", Amount: "123"}, {Stash: "BBB", Amount: "123"}},
-				Era:           currEra,
+				Era:           currActiveEra,
 			}},
 			expectedKinds: []model.RewardKind{model.RewardReward, model.RewardReward},
 		},
 		{description: "creates rewards if not last in era",
 			validator: parsedValidator{parsedRewards: parsedRewards{
 				StakerRewards: []stakerReward{{Stash: "AAA", Amount: "123"}, {Stash: "BBB", Amount: "123"}},
-				Era:           currEra,
+				Era:           currActiveEra,
 			}},
 			expectedKinds: []model.RewardKind{model.RewardReward, model.RewardReward},
 		},
 		{description: "creates rewards if validator era is different from current era",
 			validator: parsedValidator{parsedRewards: parsedRewards{
 				StakerRewards: []stakerReward{{Stash: "AAA", Amount: "123"}, {Stash: "BBB", Amount: "123"}},
-				Era:           currEra - 1,
+				Era:           currActiveEra - 1,
 			},
 			},
 			expectedKinds: []model.RewardKind{model.RewardReward, model.RewardReward},
@@ -176,14 +176,11 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 
 			pl := &payload{
 				ParsedValidators: ParsedValidatorsData{testValidator: tt.validator},
-				Syncable:         &model.Syncable{Era: currEra, LastInEra: tt.lastInEra},
+				HeightMeta:       HeightMeta{ActiveEra: currActiveEra},
 			}
 
-			dbMock.EXPECT().FindLastInEra(currEra-1).Return(&model.Syncable{Height: 500}, nil).Times(1)
-			if tt.validator.parsedRewards.Era != currEra {
-				dbMock.EXPECT().FindLastInEra(tt.validator.parsedRewards.Era).Return(&model.Syncable{Height: 500}, nil).Times(1)
-				dbMock.EXPECT().FindLastInEra(tt.validator.parsedRewards.Era-1).Return(&model.Syncable{Height: 500}, nil).Times(1)
-			}
+			dbMock.EXPECT().FindLastInEra(currActiveEra).Return(&model.Syncable{Height: 500}, nil).Times(1)
+			dbMock.EXPECT().FindLastInEra(currActiveEra-1).Return(&model.Syncable{Height: 500}, nil).Times(1)
 
 			if err := task.Run(ctx, pl); err != nil {
 				t.Errorf("unexpected error on Run, want %v; got %v", nil, err)
@@ -358,7 +355,7 @@ func TestRewardEraSeqCreatorTask_Run(t *testing.T) {
 			task := NewRewardEraSeqCreatorTask(nil, rewardsMock, syncablesMock, validatorMock)
 
 			pl := &payload{
-				Syncable: &model.Syncable{Era: currEra},
+				HeightMeta: HeightMeta{ActiveEra: currActiveEra},
 				RawBlock: &blockpb.Block{
 					Extrinsics: tt.txs,
 				},


### PR DESCRIPTION
relies on pr in [proxy](https://github.com/figment-networks/polkadothub-proxy/pull/45) (should update go.mod after pr is merged).

Fixes issue where when indexer is syncing head of the chain, rewards can't be calculated yet (at end of era). The earliest they can  be calculated is at end of the active era which happens a session after end of era 😓 