### PR TITLE
Add reindex

### DIFF
--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -37,6 +37,8 @@ func runCmd(cfg *config.Config, flags Flags) error {
 		cmdHandlers.StartIndexer.Handle(ctx, flags.batchSize)
 	case "indexer_backfill":
 		cmdHandlers.BackfillIndexer.Handle(ctx, flags.parallel, flags.force, flags.targetIds)
+	case "indexer_reindex":
+		cmdHandlers.ReindexIndexer.Handle(ctx, flags.parallel, flags.force, flags.targetIds, flags.lastInEra, flags.lastInSession, flags.trxKinds)
 	case "indexer_summarize":
 		cmdHandlers.SummarizeIndexer.Handle(ctx)
 	case "indexer_purge":

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/figment-networks/indexing-engine v0.1.14
-	github.com/figment-networks/polkadothub-proxy/grpc v0.0.0-20210312124349-b58ade405405
+	github.com/figment-networks/polkadothub-proxy/grpc v0.0.0-20210402125534-635b4b27d136
 	github.com/gin-gonic/gin v1.5.0
 	github.com/golang-migrate/migrate/v4 v4.11.0
 	github.com/golang/mock v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -37,7 +37,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
@@ -120,8 +119,8 @@ github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/figment-networks/indexing-engine v0.1.14 h1:CUC2jJL9lfebzZ4TB+63UwmmKo3KIe8nsJywF2196HU=
 github.com/figment-networks/indexing-engine v0.1.14/go.mod h1:qNrfV0A+kpAprbHS/aK1CZU2OgmVr1xkug26DO2QbY8=
-github.com/figment-networks/polkadothub-proxy/grpc v0.0.0-20210312124349-b58ade405405 h1:r84Y3onXnqMqig0a1TFB/LcTBxqWo5cRojZlLnlDi1U=
-github.com/figment-networks/polkadothub-proxy/grpc v0.0.0-20210312124349-b58ade405405/go.mod h1:Uf48ek6W9HhZw6QIrW7HEfgGUanK+kbUTeCBZaB8/NM=
+github.com/figment-networks/polkadothub-proxy/grpc v0.0.0-20210402125534-635b4b27d136 h1:9Z1J1JWLoFV53x2pCvtIyvq2l9izp//IjkbmW4Yd8tU=
+github.com/figment-networks/polkadothub-proxy/grpc v0.0.0-20210402125534-635b4b27d136/go.mod h1:DRLHiHWdqk5Jdjl5FsEE4zwQuhcTbW2meUvJWYInJWg=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -461,7 +460,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -290,6 +290,77 @@ func (p *indexingPipeline) Backfill(ctx context.Context, backfillCfg BackfillCon
 	return err
 }
 
+type ReindexConfig struct {
+	Parallel      bool
+	Force         bool
+	TargetIds     []int64
+	isLastInEra   bool
+	LastInSession bool
+	LastInEra     bool
+	TrxKinds      []model.TransactionKind
+}
+
+func (p *indexingPipeline) Reindex(ctx context.Context, cfg ReindexConfig) error {
+	if err := p.canRunBackfill(cfg.Parallel); err != nil {
+		return err
+	}
+
+	indexVersion := p.configParser.GetCurrentVersionId()
+	source, err := NewReindexSource(p.cfg, p.syncableDb, p.client, indexVersion, cfg.LastInSession, cfg.LastInEra, p.transactionDb, cfg.TrxKinds)
+	if err != nil {
+		return err
+	}
+
+	sink := NewSink(p.databaseDb, p.syncableDb, indexVersion)
+
+	kind := model.ReportKindSequentialReindex
+	if cfg.Parallel {
+		kind = model.ReportKindParallelReindex
+	}
+
+	if cfg.Force {
+		if err := p.reportDb.DeleteByKinds([]model.ReportKind{model.ReportKindParallelReindex, model.ReportKindSequentialReindex}); err != nil {
+			return err
+		}
+	}
+
+	reportCreator := &reportCreator{
+		kind:         kind,
+		indexVersion: indexVersion,
+		startHeight:  source.startHeight,
+		endHeight:    source.endHeight,
+		reportDb:     p.reportDb,
+	}
+
+	versionIds := p.status.missingVersionIds
+	pipelineOptionsCreator := &pipelineOptionsCreator{
+		configParser:      p.configParser,
+		desiredVersionIds: versionIds,
+	}
+	pipelineOptions, err := pipelineOptionsCreator.parse()
+	if err != nil {
+		return err
+	}
+
+	if err := reportCreator.createIfNotExists(model.ReportKindSequentialReindex, model.ReportKindParallelReindex); err != nil {
+		return err
+	}
+
+	ctxWithReport := context.WithValue(ctx, CtxReport, reportCreator.report)
+
+	logger.Info(fmt.Sprintf("starting pipeline reindex [start=%d] [end=%d] [kind=%s]", source.startHeight, source.endHeight, kind))
+
+	if err := p.pipeline.Start(ctxWithReport, source, sink, pipelineOptions); err != nil {
+		return err
+	}
+
+	logger.Info(fmt.Sprintf("pipeline completed [Err: %+v]", err))
+
+	err = reportCreator.complete(source.Len(), sink.successCount, err)
+
+	return err
+}
+
 func (p *indexingPipeline) canRunBackfill(isParallel bool) error {
 	if p.status.isPristine {
 		return ErrIsPristine

--- a/indexer/source_reindex.go
+++ b/indexer/source_reindex.go
@@ -1,0 +1,178 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/figment-networks/polkadothub-indexer/model"
+	"github.com/figment-networks/polkadothub-indexer/utils/logger"
+
+	"github.com/figment-networks/indexing-engine/pipeline"
+	"github.com/figment-networks/polkadothub-indexer/client"
+	"github.com/figment-networks/polkadothub-indexer/config"
+	"github.com/figment-networks/polkadothub-indexer/store"
+)
+
+var (
+	_ pipeline.Source = (*reindexSource)(nil)
+)
+
+func NewReindexSource(cfg *config.Config, syncablesDb store.Syncables, client *client.Client, indexVersion int64, isLastInSession, isLastInEra bool, transactionDb store.Transactions, trxFilter []model.TransactionKind) (*reindexSource, error) {
+	src := &reindexSource{
+		cfg:           cfg,
+		syncablesDb:   syncablesDb,
+		transactionDb: transactionDb,
+		client:        client,
+
+		currentIndexVersion: indexVersion,
+	}
+
+	if err := src.init(isLastInSession, isLastInEra, trxFilter); err != nil {
+		return nil, err
+	}
+
+	return src, nil
+}
+
+type reindexSource struct {
+	cfg                 *config.Config
+	syncablesDb         store.Syncables
+	transactionDb       store.Transactions
+	client              *client.Client
+	heightsWhitelist    map[int64]struct{}
+	sortedWhiteListKeys []int64
+	sortedIndex         int64
+	whiteListStages     []pipeline.StageName
+	currentIndexVersion int64
+	currentHeight       int64
+	startHeight         int64
+	endHeight           int64
+	err                 error
+}
+
+func (s *reindexSource) Next(context.Context, pipeline.Payload) bool {
+	s.sortedIndex = s.sortedIndex + 1
+	if s.currentHeight < s.endHeight && s.sortedIndex+1 <= int64(len(s.sortedWhiteListKeys)) {
+		s.currentHeight = s.sortedWhiteListKeys[s.sortedIndex]
+		return true
+	}
+	return false
+}
+
+func (s *reindexSource) Current() int64 {
+	return s.currentHeight
+}
+
+func (s *reindexSource) Err() error {
+	return s.err
+}
+
+func (s *reindexSource) Skip(stageName pipeline.StageName) bool {
+	return false
+}
+
+func (s *reindexSource) Len() int64 {
+	return s.endHeight - s.startHeight + 1
+}
+
+func (s *reindexSource) init(isLastInSession, isLastInEra bool, kinds []model.TransactionKind) error {
+	heightsWhitelist := make(map[int64]struct{})
+	if isLastInSession || isLastInEra {
+		if err := s.setHeightsWhitelistForEraOrSession(heightsWhitelist, isLastInSession, isLastInEra); err != nil {
+			return err
+		}
+	}
+
+	useWhiteListForTrxFilter := len(kinds) != 0
+	if useWhiteListForTrxFilter {
+		if err := s.setHeightsWhitelistForTrxFilter(heightsWhitelist, kinds); err != nil {
+			return err
+		}
+	}
+
+	if len(heightsWhitelist) == 0 {
+		return errors.New("no heights for whitelist to reindex")
+	}
+
+	logger.Info(fmt.Sprintf("[reindex] set %d heights to reindex", len(heightsWhitelist)))
+
+	keysWhitelist := make([]int64, 0, len(heightsWhitelist))
+	for k := range heightsWhitelist {
+		keysWhitelist = append(keysWhitelist, k)
+	}
+	sort.Slice(keysWhitelist, func(i, j int) bool { return keysWhitelist[i] < keysWhitelist[j] })
+	s.sortedWhiteListKeys = keysWhitelist
+
+	if err := s.setStartHeight(); err != nil {
+		return err
+	}
+	if err := s.setEndHeight(); err != nil {
+		return err
+	}
+
+	s.currentHeight = s.sortedWhiteListKeys[0]
+
+	return nil
+}
+
+func (s *reindexSource) setStartHeight() error {
+	syncable, err := s.syncablesDb.FindFirstByDifferentIndexVersion(s.currentIndexVersion)
+	if err != nil {
+		if err == store.ErrNotFound {
+			return errors.New(fmt.Sprintf("nothing to reindex [currentIndexVersion=%d]", s.currentIndexVersion))
+		}
+		return err
+	}
+
+	s.currentHeight = syncable.Height
+	s.startHeight = syncable.Height
+	return nil
+}
+
+func (s *reindexSource) setEndHeight() error {
+	syncable, err := s.syncablesDb.FindMostRecentByDifferentIndexVersion(s.currentIndexVersion)
+	if err != nil {
+		if err == store.ErrNotFound {
+			return errors.New(fmt.Sprintf("nothing to reindex [currentIndexVersion=%d]", s.currentIndexVersion))
+		}
+		return err
+	}
+
+	s.endHeight = syncable.Height
+	return nil
+}
+
+func (s *reindexSource) setHeightsWhitelistForEraOrSession(whitelist map[int64]struct{}, isLastInSession, isLastInEra bool) error {
+	syncables, err := s.syncablesDb.FindAllByLastInSessionOrEra(-1, isLastInSession, isLastInEra)
+	if err != nil {
+		return err
+	}
+
+	logger.Info(fmt.Sprintf("[setHeightsWhitelistForEraOrSession] set %d heights in whitelist", len(syncables)))
+
+	for i := 0; i < len(syncables); i++ {
+		whitelist[syncables[i].Height] = struct{}{}
+	}
+
+	return nil
+}
+
+func (s *reindexSource) setHeightsWhitelistForTrxFilter(whitelist map[int64]struct{}, kinds []model.TransactionKind) error {
+	beforelen := len(whitelist)
+
+	for _, kind := range kinds {
+		transactions, err := s.transactionDb.GetTransactionsByTransactionKind(kind)
+		if err != nil {
+			return err
+		}
+
+		for _, trx := range transactions {
+			whitelist[trx.Height] = struct{}{}
+		}
+	}
+
+	logger.Info(fmt.Sprintf("[setHeightsWhitelistForTrxFilter] set %d heights in whitelist", len(whitelist)-beforelen))
+	return nil
+}

--- a/store/psql/syncables_store.go
+++ b/store/psql/syncables_store.go
@@ -169,8 +169,10 @@ func (s SyncablesStore) SetProcessedAtForRange(reportID types.ID, startHeight in
 func (s SyncablesStore) FindAllByLastInSessionOrEra(indexVersion int64, isLastInSession, isLastInEra bool) ([]model.Syncable, error) {
 	result := []model.Syncable{}
 
-	tx := s.db.
-		Not("index_version = ?", indexVersion)
+	tx := s.db
+	if indexVersion > 0 {
+		tx = tx.Not("index_version = ?", indexVersion)
+	}
 
 	if isLastInEra {
 		tx = tx.Where("last_in_era=?", isLastInEra)

--- a/usecase/cmd_handlers.go
+++ b/usecase/cmd_handlers.go
@@ -15,6 +15,7 @@ func NewCmdHandlers(cfg *config.Config, cli *client.Client, accountDb store.Acco
 		GetStatus:        chain.NewGetStatusCmdHandler(cli, syncableDb),
 		StartIndexer:     indexing.NewStartCmdHandler(cfg, cli, accountDb, blockDb, databaseDb, eventDb, reportDb, rewardDb, syncableDb, systemEventDb, transactionDb, validatorDb),
 		BackfillIndexer:  indexing.NewBackfillCmdHandler(cfg, cli, accountDb, blockDb, databaseDb, eventDb, reportDb, rewardDb, syncableDb, systemEventDb, transactionDb, validatorDb),
+		ReindexIndexer:   indexing.NewReindexCmdHandler(cfg, cli, accountDb, blockDb, databaseDb, eventDb, reportDb, rewardDb, syncableDb, systemEventDb, transactionDb, validatorDb),
 		PurgeIndexer:     indexing.NewPurgeCmdHandler(cfg, blockDb, validatorDb),
 		SummarizeIndexer: indexing.NewSummarizeCmdHandler(cfg, blockDb, validatorDb),
 	}
@@ -24,6 +25,7 @@ type CmdHandlers struct {
 	GetStatus        *chain.GetStatusCmdHandler
 	StartIndexer     *indexing.StartCmdHandler
 	BackfillIndexer  *indexing.BackfillCmdHandler
+	ReindexIndexer   *indexing.ReindexCmdHandler
 	PurgeIndexer     *indexing.PurgeCmdHandler
 	SummarizeIndexer *indexing.SummarizeCmdHandler
 }

--- a/usecase/indexing/reindex.go
+++ b/usecase/indexing/reindex.go
@@ -1,0 +1,97 @@
+package indexing
+
+import (
+	"context"
+	"errors"
+
+	"github.com/figment-networks/polkadothub-indexer/client"
+	"github.com/figment-networks/polkadothub-indexer/config"
+	"github.com/figment-networks/polkadothub-indexer/indexer"
+	"github.com/figment-networks/polkadothub-indexer/model"
+	"github.com/figment-networks/polkadothub-indexer/store"
+)
+
+var (
+	ErrReindexRunning = errors.New("reindex already running (use force flag to override it)")
+)
+
+type reindexUseCase struct {
+	cfg    *config.Config
+	client *client.Client
+
+	accountDb     store.Accounts
+	blockDb       store.Blocks
+	databaseDb    store.Database
+	eventDb       store.Events
+	reportDb      store.Reports
+	rewardDb      store.Rewards
+	syncableDb    store.Syncables
+	systemEventDb store.SystemEvents
+	transactionDb store.Transactions
+	validatorDb   store.Validators
+}
+
+func NewReindexUseCase(cfg *config.Config, cli *client.Client, accountDb store.Accounts, blockDb store.Blocks, databaseDb store.Database, eventDb store.Events,
+	reportDb store.Reports, rewardDb store.Rewards, syncableDb store.Syncables, systemEventDb store.SystemEvents, transactionDb store.Transactions, validatorDb store.Validators,
+) *reindexUseCase {
+	return &reindexUseCase{
+		cfg:    cfg,
+		client: cli,
+
+		accountDb:     accountDb,
+		blockDb:       blockDb,
+		databaseDb:    databaseDb,
+		eventDb:       eventDb,
+		reportDb:      reportDb,
+		rewardDb:      rewardDb,
+		syncableDb:    syncableDb,
+		systemEventDb: systemEventDb,
+		transactionDb: transactionDb,
+		validatorDb:   validatorDb,
+	}
+}
+
+type ReindexUseCaseConfig struct {
+	Parallel      bool
+	Force         bool
+	TargetIds     []int64
+	LastInSession bool
+	LastInEra     bool
+	TrxKinds      []model.TransactionKind
+}
+
+func (uc *reindexUseCase) Execute(ctx context.Context, useCaseConfig ReindexUseCaseConfig) error {
+	if err := uc.canExecute(useCaseConfig.Force); err != nil {
+		return err
+	}
+
+	indexingPipeline, err := indexer.NewPipeline(uc.cfg, uc.client, uc.accountDb, uc.blockDb, uc.databaseDb, uc.eventDb, uc.reportDb, uc.rewardDb, uc.syncableDb, uc.systemEventDb, uc.transactionDb, uc.validatorDb)
+	if err != nil {
+		return err
+	}
+
+	return indexingPipeline.Reindex(ctx, indexer.ReindexConfig{
+		Parallel:      useCaseConfig.Parallel,
+		Force:         useCaseConfig.Force,
+		TargetIds:     useCaseConfig.TargetIds,
+		LastInSession: useCaseConfig.LastInSession,
+		LastInEra:     useCaseConfig.LastInEra,
+		TrxKinds:      useCaseConfig.TrxKinds,
+	})
+}
+
+// canExecute checks if reindex is already running
+// if is it running and force is not set as true then we skip indexing
+func (uc *reindexUseCase) canExecute(force bool) error {
+	if force {
+		return nil
+	}
+
+	if _, err := uc.reportDb.FindNotCompletedByKind(model.ReportKindSequentialReindex, model.ReportKindParallelReindex); err != nil {
+		if err == store.ErrNotFound {
+			return nil
+		}
+		return err
+	}
+	return ErrReindexRunning
+}

--- a/usecase/indexing/reindex_cmd_handler.go
+++ b/usecase/indexing/reindex_cmd_handler.go
@@ -1,0 +1,74 @@
+package indexing
+
+import (
+	"context"
+
+	"github.com/figment-networks/polkadothub-indexer/client"
+	"github.com/figment-networks/polkadothub-indexer/config"
+	"github.com/figment-networks/polkadothub-indexer/model"
+	"github.com/figment-networks/polkadothub-indexer/store"
+	"github.com/figment-networks/polkadothub-indexer/utils/logger"
+)
+
+type ReindexCmdHandler struct {
+	cfg    *config.Config
+	client *client.Client
+
+	useCase *reindexUseCase
+
+	accountDb     store.Accounts
+	blockDb       store.Blocks
+	databaseDb    store.Database
+	eventDb       store.Events
+	reportDb      store.Reports
+	rewardDb      store.Rewards
+	syncableDb    store.Syncables
+	systemEventDb store.SystemEvents
+	transactionDb store.Transactions
+	validatorDb   store.Validators
+}
+
+func NewReindexCmdHandler(cfg *config.Config, cli *client.Client, accountDb store.Accounts, blockDb store.Blocks, databaseDb store.Database, eventDb store.Events, reportDb store.Reports,
+	rewardDb store.Rewards, syncableDb store.Syncables, systemEventDb store.SystemEvents, transactionDb store.Transactions, validatorDb store.Validators,
+) *ReindexCmdHandler {
+	return &ReindexCmdHandler{
+		cfg:    cfg,
+		client: cli,
+
+		accountDb:     accountDb,
+		blockDb:       blockDb,
+		databaseDb:    databaseDb,
+		eventDb:       eventDb,
+		reportDb:      reportDb,
+		rewardDb:      rewardDb,
+		syncableDb:    syncableDb,
+		systemEventDb: systemEventDb,
+		transactionDb: transactionDb,
+		validatorDb:   validatorDb,
+	}
+}
+
+func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, force bool, targetIds []int64, lastInEra bool, lastInSession bool, trxKinds []model.TransactionKind) {
+	logger.Info("running reindex use case [handler=cmd]")
+
+	useCaseConfig := ReindexUseCaseConfig{
+		Parallel:      parallel,
+		Force:         force,
+		TargetIds:     targetIds,
+		LastInSession: lastInSession,
+		LastInEra:     lastInEra,
+		TrxKinds:      trxKinds,
+	}
+	err := h.getUseCase().Execute(ctx, useCaseConfig)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+}
+
+func (h *ReindexCmdHandler) getUseCase() *reindexUseCase {
+	if h.useCase == nil {
+		return NewReindexUseCase(h.cfg, h.client, h.accountDb, h.blockDb, h.databaseDb, h.eventDb, h.reportDb, h.rewardDb, h.syncableDb, h.systemEventDb, h.transactionDb, h.validatorDb)
+	}
+	return h.useCase
+}


### PR DESCRIPTION
This PR adds the ability to reindex heights without having to update indexer_config (previously would need to update indexer config to add new version, even if the version didn't change ie no new db fields or changes to structs) .

It adds new cmd `indexer_reindex` which allows us to reindex only heights that fulfill certain requirements (ex types of transactions, or if last in era). It creates a whitelist of all heights that meet that condition, and reindexes only those heights. Later we can add additional flags to pass desired heights directly. This does not alter the config version.

If you need to reindex entire blockchain (eg because of additional field added to db, and subsequently there's been a config version change), update indexer_config.json with new version  then run `indexer_backfill` cmd.

example command:
`go run main.go -config config.example.json -cmd indexer_reindex -parallel -target_ids 12  -last_in_era -trx_kinds utility.batch,utility.batchAll,staking.payoutStakers -force`