### PR TITLE
Add fields toreindex

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,13 +21,15 @@ type Flags struct {
 	migrateVersion uint
 	showVersion    bool
 
-	batchSize     int64
-	parallel      bool
-	force         bool
-	targetIds     targetIds
-	trxKinds      trxKinds
-	lastInEra     bool
-	lastInSession bool
+	batchSize          int64
+	parallel           bool
+	force              bool
+	targetIds          targetIds
+	trxKinds           trxKinds
+	startReindexHeight int64
+	endReindexHeight   int64
+	lastInEra          bool
+	lastInSession      bool
 }
 
 type targetIds []int64
@@ -87,7 +89,8 @@ func (c *Flags) Setup() {
 	flag.Var(&c.trxKinds, "trx_kinds", "comma separated list of transaction kinds to run in reindex cmd in the format section.method")
 	flag.BoolVar(&c.lastInEra, "last_in_era", false, "should reindex last in era for reindex cmd")
 	flag.BoolVar(&c.lastInSession, "last_in_session", false, "should reindex last in session for reindex cmd")
-
+	flag.Int64Var(&c.startReindexHeight, "start_height", 0, "start height for reindex cmd")
+	flag.Int64Var(&c.endReindexHeight, "end_height", 0, "end height for reindex cmd")
 }
 
 // Run executes the command line interface

--- a/cli/cmd.go
+++ b/cli/cmd.go
@@ -38,7 +38,7 @@ func runCmd(cfg *config.Config, flags Flags) error {
 	case "indexer_backfill":
 		cmdHandlers.BackfillIndexer.Handle(ctx, flags.parallel, flags.force, flags.targetIds)
 	case "indexer_reindex":
-		cmdHandlers.ReindexIndexer.Handle(ctx, flags.parallel, flags.force, flags.targetIds, flags.lastInEra, flags.lastInSession, flags.trxKinds)
+		cmdHandlers.ReindexIndexer.Handle(ctx, flags.parallel, flags.force, flags.targetIds, flags.lastInEra, flags.lastInSession, flags.trxKinds, flags.startReindexHeight, flags.endReindexHeight)
 	case "indexer_summarize":
 		cmdHandlers.SummarizeIndexer.Handle(ctx)
 	case "indexer_purge":

--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -298,6 +298,8 @@ type ReindexConfig struct {
 	LastInSession bool
 	LastInEra     bool
 	TrxKinds      []model.TransactionKind
+	StartHeight   int64
+	EndHeight     int64
 }
 
 func (p *indexingPipeline) Reindex(ctx context.Context, cfg ReindexConfig) error {
@@ -306,7 +308,7 @@ func (p *indexingPipeline) Reindex(ctx context.Context, cfg ReindexConfig) error
 	}
 
 	indexVersion := p.configParser.GetCurrentVersionId()
-	source, err := NewReindexSource(p.cfg, p.syncableDb, p.client, indexVersion, cfg.LastInSession, cfg.LastInEra, p.transactionDb, cfg.TrxKinds)
+	source, err := NewReindexSource(p.cfg, p.syncableDb, p.transactionDb, p.client, indexVersion, cfg.LastInSession, cfg.LastInEra, cfg.TrxKinds, cfg.StartHeight, cfg.EndHeight)
 	if err != nil {
 		return err
 	}

--- a/indexer/source_backfill.go
+++ b/indexer/source_backfill.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/figment-networks/polkadothub-indexer/model"
 
 	"github.com/figment-networks/indexing-engine/pipeline"
@@ -144,7 +145,7 @@ func (s *backfillSource) setEndHeight() error {
 }
 
 func (s *backfillSource) setHeightsWhitelistForEra(isLastInSession, isLastInEra bool) error {
-	syncables, err := s.syncablesDb.FindAllByLastInSessionOrEra(s.currentIndexVersion, isLastInSession, isLastInEra)
+	syncables, err := s.syncablesDb.FindAllByLastInSessionOrEra(s.currentIndexVersion, isLastInSession, isLastInEra, 0, 0)
 	if err != nil {
 		return err
 	}
@@ -162,7 +163,7 @@ func (s *backfillSource) setHeightsWhitelistForEra(isLastInSession, isLastInEra 
 
 func (s *backfillSource) setHeightsWhitelistForTrxFilter(kinds []model.TransactionKind) error {
 	for _, kind := range kinds {
-		transactions, err := s.transactionDb.GetTransactionsByTransactionKind(kind)
+		transactions, err := s.transactionDb.GetTransactionsByTransactionKind(kind, 0, 0)
 		if err != nil {
 			return err
 		}

--- a/mock/store/mocks.go
+++ b/mock/store/mocks.go
@@ -712,18 +712,18 @@ func (mr *MockRewardsMockRecorder) BulkUpsert(arg0 interface{}) *gomock.Call {
 }
 
 // GetAll mocks base method
-func (m *MockRewards) GetAll(arg0 string, arg1, arg2 int64) ([]model.RewardEraSeq, error) {
+func (m *MockRewards) GetAll(arg0, arg1 string, arg2, arg3 int64) ([]model.RewardEraSeq, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAll", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetAll", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]model.RewardEraSeq)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAll indicates an expected call of GetAll
-func (mr *MockRewardsMockRecorder) GetAll(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRewardsMockRecorder) GetAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockRewards)(nil).GetAll), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockRewards)(nil).GetAll), arg0, arg1, arg2, arg3)
 }
 
 // GetByStashAndEra mocks base method

--- a/store/psql/reward_era_seq_store.go
+++ b/store/psql/reward_era_seq_store.go
@@ -74,7 +74,7 @@ func (s RewardEraSeqStore) MarkAllClaimed(validatorStash string, era int64, txHa
 }
 
 // GetAll Gets all rewards for given stash
-func (s RewardEraSeqStore) GetAll(stash string, start, end int64) ([]model.RewardEraSeq, error) {
+func (s RewardEraSeqStore) GetAll(stash, validatorStash string, start, end int64) ([]model.RewardEraSeq, error) {
 	tx := s.db.
 		Table(model.RewardEraSeq{}.TableName()).
 		Select("*").
@@ -86,6 +86,10 @@ func (s RewardEraSeqStore) GetAll(stash string, start, end int64) ([]model.Rewar
 	}
 	if start != 0 {
 		tx = tx.Where("era >= ?", start)
+	}
+
+	if validatorStash != "" {
+		tx = tx.Where("validator_stash_account = ?", validatorStash)
 	}
 
 	var res []model.RewardEraSeq

--- a/store/psql/syncables_store.go
+++ b/store/psql/syncables_store.go
@@ -166,7 +166,7 @@ func (s SyncablesStore) SetProcessedAtForRange(reportID types.ID, startHeight in
 }
 
 // FindAllByLastInSessionOrEra returns end syncs of sessions and eras
-func (s SyncablesStore) FindAllByLastInSessionOrEra(indexVersion int64, isLastInSession, isLastInEra bool) ([]model.Syncable, error) {
+func (s SyncablesStore) FindAllByLastInSessionOrEra(indexVersion int64, isLastInSession, isLastInEra bool, start, end int64) ([]model.Syncable, error) {
 	result := []model.Syncable{}
 
 	tx := s.db
@@ -180,6 +180,14 @@ func (s SyncablesStore) FindAllByLastInSessionOrEra(indexVersion int64, isLastIn
 
 	if isLastInSession {
 		tx = tx.Where("last_in_session=?", isLastInSession)
+	}
+
+	if start > 0 {
+		tx = tx.Where("height >= ?", start)
+	}
+
+	if end > 0 {
+		tx = tx.Where("height <= ?", end)
 	}
 
 	return result, checkErr(tx.Find(&result).Error)

--- a/store/psql/transaction_seq_store.go
+++ b/store/psql/transaction_seq_store.go
@@ -33,12 +33,21 @@ func (s TransactionSeqStore) BulkUpsert(records []model.TransactionSeq) error {
 }
 
 // GetTransactionsByTransactionKind gets transactions by kind
-func (s TransactionSeqStore) GetTransactionsByTransactionKind(kind model.TransactionKind) ([]model.TransactionSeq, error) {
+func (s TransactionSeqStore) GetTransactionsByTransactionKind(kind model.TransactionKind, start, end int64) ([]model.TransactionSeq, error) {
 	var results []model.TransactionSeq
 
-	err := s.db.
-		Where("method = ? AND section = ?", kind.Method, kind.Section).
-		Find(&results).
+	tx := s.db.
+		Where("method = ? AND section = ?", kind.Method, kind.Section)
+
+	if start > 0 {
+		tx = tx.Where("height >= ?", start)
+	}
+
+	if end > 0 {
+		tx = tx.Where("height <= ?", end)
+	}
+
+	err := tx.Find(&results).
 		Error
 
 	return results, checkErr(err)

--- a/store/store.go
+++ b/store/store.go
@@ -32,7 +32,7 @@ type Reports interface {
 type Rewards interface {
 	BulkUpsert(records []model.RewardEraSeq) error
 	MarkAllClaimed(validatorStash string, era int64, txHash string) error
-	GetAll(address string, start, end int64) ([]model.RewardEraSeq, error)
+	GetAll(stash, validatorStash string, start, end int64) ([]model.RewardEraSeq, error)
 	GetCount(validatorStash string, era int64) (int64, error)
 	GetByStashAndEra(validatorStash, stash string, era int64) (model.RewardEraSeq, error)
 }

--- a/store/syncables.go
+++ b/store/syncables.go
@@ -18,7 +18,7 @@ type syncables interface {
 	FindSmallestIndexVersion() (*int64, error)
 	SaveSyncable(*model.Syncable) error
 	SetProcessedAtForRange(reportID types.ID, startHeight int64, endHeight int64) error
-	FindAllByLastInSessionOrEra(indexVersion int64, isLastInSession, isLastInEra bool) ([]model.Syncable, error)
+	FindAllByLastInSessionOrEra(indexVersion int64, isLastInSession, isLastInEra bool, start, end int64) ([]model.Syncable, error)
 }
 
 type FindMostRecenter interface {

--- a/store/transactions.go
+++ b/store/transactions.go
@@ -6,5 +6,5 @@ import (
 
 type TransactionSeq interface {
 	BulkUpsert(records []model.TransactionSeq) error
-	GetTransactionsByTransactionKind(kind model.TransactionKind) ([]model.TransactionSeq, error)
+	GetTransactionsByTransactionKind(kind model.TransactionKind, start, end int64) ([]model.TransactionSeq, error)
 }

--- a/swagger.json
+++ b/swagger.json
@@ -97,7 +97,7 @@
             "x-go-name": "Start",
             "description": "Start",
             "name": "start",
-            "in": "path",
+            "in": "query",
             "required": true
           },
           {
@@ -107,8 +107,7 @@
             "x-go-name": "End",
             "description": "End",
             "name": "end",
-            "in": "path",
-            "required": true
+            "in": "query"
           }
         ],
         "responses": {
@@ -249,8 +248,7 @@
             "x-go-name": "Start",
             "description": "Start",
             "name": "start",
-            "in": "path",
-            "required": true
+            "in": "query"
           },
           {
             "type": "integer",
@@ -258,8 +256,14 @@
             "x-go-name": "End",
             "description": "End",
             "name": "end",
-            "in": "path",
-            "required": true
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "ValidatorStash",
+            "description": "ValidatorStash",
+            "name": "validator",
+            "in": "query"
           }
         ],
         "responses": {
@@ -397,7 +401,7 @@
             "x-go-name": "StashAccount",
             "description": "StashAccount",
             "name": "stash_account",
-            "in": "query",
+            "in": "path",
             "required": true
           },
           {
@@ -467,7 +471,7 @@
         "produces": [
           "application/json"
         ],
-        "summary": "Gets all validator aggregate information after height",
+        "summary": "Gets all validator aggregates for validators which are active after min height",
         "operationId": "getValidatorForMinHeight",
         "parameters": [
           {

--- a/usecase/account/get_rewards_http_handler.go
+++ b/usecase/account/get_rewards_http_handler.go
@@ -45,12 +45,12 @@ type queryParams struct {
 	// Start
 	//
 	// required: true
-	// in: path
+	// in: query
 	// example: 2006-01-02 15:04:05
 	Start time.Time `json:"start" form:"start" binding:"required" time_format:"2006-01-02 15:04:05"`
 	// End
 	//
-	// in: path
+	// in: query
 	// example: 2006-01-02 15:04:05
 	End time.Time `json:"end" form:"end" binding:"-" time_format:"2006-01-02 15:04:05"`
 }

--- a/usecase/indexing/reindex.go
+++ b/usecase/indexing/reindex.go
@@ -58,6 +58,8 @@ type ReindexUseCaseConfig struct {
 	LastInSession bool
 	LastInEra     bool
 	TrxKinds      []model.TransactionKind
+	StartHeight   int64
+	EndHeight     int64
 }
 
 func (uc *reindexUseCase) Execute(ctx context.Context, useCaseConfig ReindexUseCaseConfig) error {
@@ -77,6 +79,8 @@ func (uc *reindexUseCase) Execute(ctx context.Context, useCaseConfig ReindexUseC
 		LastInSession: useCaseConfig.LastInSession,
 		LastInEra:     useCaseConfig.LastInEra,
 		TrxKinds:      useCaseConfig.TrxKinds,
+		StartHeight:   useCaseConfig.StartHeight,
+		EndHeight:     useCaseConfig.EndHeight,
 	})
 }
 

--- a/usecase/indexing/reindex_cmd_handler.go
+++ b/usecase/indexing/reindex_cmd_handler.go
@@ -48,7 +48,7 @@ func NewReindexCmdHandler(cfg *config.Config, cli *client.Client, accountDb stor
 	}
 }
 
-func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, force bool, targetIds []int64, lastInEra bool, lastInSession bool, trxKinds []model.TransactionKind) {
+func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, force bool, targetIds []int64, lastInEra bool, lastInSession bool, trxKinds []model.TransactionKind, startHeight, endHeight int64) {
 	logger.Info("running reindex use case [handler=cmd]")
 
 	useCaseConfig := ReindexUseCaseConfig{
@@ -58,6 +58,8 @@ func (h *ReindexCmdHandler) Handle(ctx context.Context, parallel bool, force boo
 		LastInSession: lastInSession,
 		LastInEra:     lastInEra,
 		TrxKinds:      trxKinds,
+		StartHeight:   startHeight,
+		EndHeight:     endHeight,
 	}
 	err := h.getUseCase().Execute(ctx, useCaseConfig)
 	if err != nil {

--- a/usecase/reward/get_for_address.go
+++ b/usecase/reward/get_for_address.go
@@ -18,8 +18,8 @@ func NewGetForStashAccountUseCase(rewardDb store.Rewards) *getForStashAccountUse
 // swagger:response RewardsForErasView
 type RewardsForErasView []model.RewardEraSeq
 
-func (uc *getForStashAccountUseCase) Execute(stash string, start, end int64) ([]model.RewardEraSeq, error) {
-	rewards, err := uc.rewardDb.GetAll(stash, start, end)
+func (uc *getForStashAccountUseCase) Execute(stash string, start, end int64, validatorStash string) ([]model.RewardEraSeq, error) {
+	rewards, err := uc.rewardDb.GetAll(stash, validatorStash, start, end)
 	if err != nil {
 		return nil, err
 	}

--- a/usecase/reward/get_for_address_http_handler.go
+++ b/usecase/reward/get_for_address_http_handler.go
@@ -28,36 +28,45 @@ func NewGetForStashAccountHttpHandler(rewardDb store.Rewards) *getForStashAccoun
 }
 
 // swagger:parameters getRewards
-type GetForStashAccountRequest struct {
+type uriParams struct {
 	// StashAccount
 	//
 	// required: true
 	// in: path
 	StashAccount string `json:"stash_account" uri:"stash_account" binding:"required"`
+}
+
+// swagger:parameters getRewards
+type queryParams struct {
 	// Start
 	//
-	// in: path
+	// in: query
 	Start int64 `json:"start"  form:"start" binding:"-"`
 	// End
 	//
-	// in: path
+	// in: query
 	End int64 `json:"end"  form:"end" binding:"-"`
+	// ValidatorStash
+	//
+	// in: query
+	ValidatorStash string `json:"validator" form:"validator" binding:"-"`
 }
 
 func (h *getForStashAccountHttpHandler) Handle(c *gin.Context) {
-	var req GetForStashAccountRequest
-	if err := c.ShouldBindUri(&req); err != nil {
+	var uri uriParams
+	if err := c.ShouldBindUri(&uri); err != nil {
 		logger.Error(err)
 		http.BadRequest(c, errors.New("invalid stash account"))
 		return
 	}
-	if err := c.ShouldBindQuery(&req); err != nil {
+	var query queryParams
+	if err := c.ShouldBindQuery(&query); err != nil {
 		logger.Error(err)
-		http.BadRequest(c, errors.New("invalid start or/and end"))
+		http.BadRequest(c, errors.New("invalid start and/or end and/or validator"))
 		return
 	}
 
-	resp, err := h.getUseCase().Execute(req.StashAccount, req.Start, req.End)
+	resp, err := h.getUseCase().Execute(uri.StashAccount, query.Start, query.End, query.ValidatorStash)
 	if err != nil {
 		logger.Error(err)
 		http.ServerError(c, err)

--- a/usecase/validator/get_by_stash_account_http_handler.go
+++ b/usecase/validator/get_by_stash_account_http_handler.go
@@ -34,7 +34,7 @@ type GetByEntityUidRequest struct {
 	// StashAccount
 	//
 	// required: true
-	// in: query
+	// in: path
 	StashAccount string `json:"stash_account" uri:"stash_account" binding:"required"`
 	// SessionsLimit
 	//


### PR DESCRIPTION
Pr achieves 2 things:

1) adds validator param to /rewards/:addr endpoint. This lets us filter rewards by validator [notion](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=b92ba906caca43719ee05d19d7389be9)
2) Add start/end flags for reindex cmd. Since reindex isn't based on config version, we shouldn't be setting start/end based on config version. We provide these manually instead. If start isn't provided, reindex starts from height 1. If end not provided, reindex ends at most recent syncable height.