### PR TITLE
Fix/validators route

### DIFF
--- a/indexer/config_parser_test.go
+++ b/indexer/config_parser_test.go
@@ -1,9 +1,9 @@
 package indexer
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/figment-networks/indexing-engine/pipeline"
 	"github.com/figment-networks/polkadothub-indexer/utils/test"
 )
 
@@ -53,6 +53,8 @@ func TestConfigParser_GetAllTasks(t *testing.T) {
 			}
     	`)
 
+		expectTasks := []pipeline.TaskName{"Task1", "Task2", "Task3", "Task4", "Task5"}
+
 		test.CreateFile(t, fileName, targetsJsonBlob)
 		defer test.CleanUp(t, fileName)
 
@@ -64,14 +66,19 @@ func TestConfigParser_GetAllTasks(t *testing.T) {
 
 		tasks := parser.GetAllAvailableTasks()
 
-		if len(tasks) != 5 {
-			t.Errorf("unexpected tasks length, want: %d; got: %d", 5, len(tasks))
+		if len(tasks) != len(expectTasks) {
+			t.Errorf("unexpected tasks length, want: %d; got: %d", len(expectTasks), len(tasks))
 		}
 
-		for i := 0; i < len(tasks); i++ {
-			taskName := fmt.Sprintf("Task%d", i+1)
-			if string(tasks[i]) != taskName {
-				t.Errorf("unexpected task at index %d, want: %s, got: %s", i, taskName, tasks[i])
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range tasks {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, tasks)
 			}
 		}
 	})
@@ -109,6 +116,7 @@ func TestConfigParser_GetAllTasks(t *testing.T) {
 			  ]
 			}
     	`)
+		expectTasks := []pipeline.TaskName{"SharedTask1", "SharedTask2", "Task1", "Task2", "Task3", "Task4", "Task5"}
 
 		test.CreateFile(t, fileName, targetsJsonBlob)
 		defer test.CleanUp(t, fileName)
@@ -121,22 +129,19 @@ func TestConfigParser_GetAllTasks(t *testing.T) {
 
 		tasks := parser.GetAllAvailableTasks()
 
-		if len(tasks) != 7 {
-			t.Errorf("unexpected tasks length, want: %d; got: %d", 7, len(tasks))
+		if len(tasks) != len(expectTasks) {
+			t.Errorf("unexpected tasks length, want: %d; got: %d", len(expectTasks), len(tasks))
 		}
 
-		if string(tasks[0]) != "SharedTask1" {
-			t.Errorf("unexpected task at index %d, want: %s, got: %s", 0, "SharedTask1", tasks[0])
-		}
-
-		if string(tasks[1]) != "SharedTask2" {
-			t.Errorf("unexpected task at index %d, want: %s, got: %s", 1, "SharedTask2", tasks[1])
-		}
-
-		for i := 2; i < len(tasks); i++ {
-			taskName := fmt.Sprintf("Task%d", i-1)
-			if string(tasks[i]) != taskName {
-				t.Errorf("unexpected task at index %d, want: %s, got: %s", i, taskName, tasks[i])
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range tasks {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, tasks)
 			}
 		}
 	})
@@ -194,6 +199,8 @@ func TestConfigParser_GetTasksByVersionIds(t *testing.T) {
 		}
 	`)
 
+	expectTasks := []pipeline.TaskName{"Task1", "Task2", "Task3", "Task4", "Task5"}
+
 	t.Run("returns tasks for given version id", func(t *testing.T) {
 		test.CreateFile(t, fileName, targetsJsonBlob)
 		defer test.CleanUp(t, fileName)
@@ -204,20 +211,21 @@ func TestConfigParser_GetTasksByVersionIds(t *testing.T) {
 			return
 		}
 
-		tasks, err := parser.GetTasksByVersionIds([]int64{1})
+		tasks, err := parser.getTasksByVersionIds([]int64{1})
 		if err != nil {
 			t.Errorf("GetTasksForVersion should not return error: err=%+v", err)
 			return
 		}
 
-		if len(tasks) != 5 {
-			t.Errorf("unexpected tasks length, want: %d; got: %d", 5, len(tasks))
-		}
-
-		for i := 0; i < len(tasks); i++ {
-			taskName := fmt.Sprintf("Task%d", i+1)
-			if string(tasks[i]) != taskName {
-				t.Errorf("unexpected task at index %d, want: %s, got: %s", i, taskName, tasks[i])
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range tasks {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, tasks)
 			}
 		}
 	})
@@ -232,7 +240,7 @@ func TestConfigParser_GetTasksByVersionIds(t *testing.T) {
 			return
 		}
 
-		_, err = parser.GetTasksByVersionIds([]int64{40})
+		_, err = parser.getTasksByVersionIds([]int64{40})
 		if err == nil {
 			t.Errorf("GetTasksForVersion should return error")
 		}
@@ -282,6 +290,8 @@ func TestConfigParser_GetTasksByTargetIds(t *testing.T) {
 			}
     	`)
 
+		expectTasks := []pipeline.TaskName{"Task1", "Task2", "Task3", "Task4", "Task5"}
+
 		test.CreateFile(t, fileName, targetsJsonBlob)
 		defer test.CleanUp(t, fileName)
 
@@ -291,20 +301,21 @@ func TestConfigParser_GetTasksByTargetIds(t *testing.T) {
 			return
 		}
 
-		tasks, err := parser.GetTasksByTargetIds([]int64{1, 2})
+		tasks, err := parser.getTasksByTargetIds([]int64{1, 2})
 		if err != nil {
 			t.Errorf("GetTasksByTargetIds should not return error: err=%+v", err)
 			return
 		}
 
-		if len(tasks) != 5 {
-			t.Errorf("unexpected tasks length, want: %d; got: %d", 5, len(tasks))
-		}
-
-		for i := 0; i < len(tasks); i++ {
-			taskName := fmt.Sprintf("Task%d", i+1)
-			if string(tasks[i]) != taskName {
-				t.Errorf("unexpected task at index %d, want: %s, got: %s", i, taskName, tasks[i])
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range tasks {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, tasks)
 			}
 		}
 	})
@@ -448,6 +459,8 @@ func TestConfigParser_GetAllVersionedTasks(t *testing.T) {
 		}
 	`)
 
+	expectTasks := []pipeline.TaskName{"Task1", "Task2", "Task3", "Task4", "Task5", "Task6", "Task7", "Task8"}
+
 	t.Run("returns tasks for targets 1, 2 and 3 from versions and not target 4", func(t *testing.T) {
 		test.CreateFile(t, fileName, targetsJsonBlob)
 		defer test.CleanUp(t, fileName)
@@ -464,14 +477,15 @@ func TestConfigParser_GetAllVersionedTasks(t *testing.T) {
 			return
 		}
 
-		if len(tasks) != 8 {
-			t.Errorf("unexpected tasks length, want: %d; got: %d", 5, len(tasks))
-		}
-
-		for i := 0; i < len(tasks); i++ {
-			taskName := fmt.Sprintf("Task%d", i+1)
-			if string(tasks[i]) != taskName {
-				t.Errorf("unexpected task at index %d, want: %s, got: %s", i, taskName, tasks[i])
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range tasks {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, tasks)
 			}
 		}
 	})

--- a/indexer/fetcher_tasks.go
+++ b/indexer/fetcher_tasks.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	FetcherTaskName          = "Fetcher"
-	ValidatorFetcherTaskName = "ValidatorFetcher"
+	FetcherTaskName                     = "Fetcher"
+	ValidatorFetcherTaskName            = "ValidatorFetcher"
+	ValidatorPerformanceFetcherTaskName = "ValidatorPerformanceFetcher"
 )
 
 type HeightMeta struct {
@@ -117,5 +118,38 @@ func (t *ValidatorFetcherTask) Run(ctx context.Context, p pipeline.Payload) erro
 	)
 
 	payload.RawValidators = validators.GetValidators()
+	return nil
+}
+
+func NewValidatorPerformanceFetcherTask(client client.ValidatorPerformanceClient) pipeline.Task {
+	return &ValidatorPerformanceFetcherTask{
+		client: client,
+	}
+}
+
+type ValidatorPerformanceFetcherTask struct {
+	client client.ValidatorPerformanceClient
+}
+
+func (t *ValidatorPerformanceFetcherTask) GetName() string {
+	return ValidatorPerformanceFetcherTaskName
+}
+
+func (t *ValidatorPerformanceFetcherTask) Run(ctx context.Context, p pipeline.Payload) error {
+	payload := p.(*payload)
+	validators, err := t.client.GetByHeight(payload.CurrentHeight)
+	if err != nil {
+		return err
+	}
+
+	logger.Info(fmt.Sprintf("running indexer task [stage=%s] [task=%s] [height=%d]", pipeline.StageFetcher, t.GetName(), payload.CurrentHeight))
+	logger.DebugJSON(validators.GetValidators(),
+		logger.Field("process", "pipeline"),
+		logger.Field("stage", pipeline.StageFetcher),
+		logger.Field("request", "validator"),
+		logger.Field("height", payload.CurrentHeight),
+	)
+
+	payload.RawValidatorPerformance = validators.GetValidators()
 	return nil
 }

--- a/indexer/fetcher_tasks.go
+++ b/indexer/fetcher_tasks.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	FetcherTaskName                     = "Fetcher"
+	FetcherTaskName                     = "FetchAll"
 	ValidatorFetcherTaskName            = "ValidatorFetcher"
 	ValidatorPerformanceFetcherTaskName = "ValidatorPerformanceFetcher"
 )

--- a/indexer/pipeline.go
+++ b/indexer/pipeline.go
@@ -53,6 +53,7 @@ func NewPipeline(cfg *config.Config, cli *client.Client, accountDb store.Account
 			pipeline.StageFetcher,
 			pipeline.RetryingTask(NewFetcherTask(cli.Height), isTransient, maxRetries),
 			pipeline.RetryingTask(NewValidatorFetcherTask(cli.Validator), isTransient, maxRetries),
+			pipeline.RetryingTask(NewValidatorPerformanceFetcherTask(cli.ValidatorPerformance), isTransient, maxRetries),
 		),
 	)
 

--- a/indexer/pipeline_options_creator.go
+++ b/indexer/pipeline_options_creator.go
@@ -13,7 +13,7 @@ type pipelineOptionsCreator struct {
 }
 
 func (o *pipelineOptionsCreator) parse() (*pipeline.Options, error) {
-	taskWhitelist, err := o.getTasksWhitelist()
+	taskWhitelist, err := o.configParser.GetAllTasks(o.desiredVersionIds, o.desiredTargetIds)
 	if err != nil {
 		return nil, err
 	}
@@ -22,28 +22,6 @@ func (o *pipelineOptionsCreator) parse() (*pipeline.Options, error) {
 		TaskWhitelist:   taskWhitelist,
 		StagesBlacklist: o.getStagesBlacklist(),
 	}, nil
-}
-
-func (o *pipelineOptionsCreator) getTasksWhitelist() ([]pipeline.TaskName, error) {
-	var taskWhitelist []pipeline.TaskName
-
-	if len(o.desiredVersionIds) > 0 {
-		tasks, err := o.configParser.GetTasksByVersionIds(o.desiredVersionIds)
-		if err != nil {
-			return nil, err
-		}
-		taskWhitelist = append(taskWhitelist, tasks...)
-	}
-
-	if len(o.desiredTargetIds) > 0 {
-		tasks, err := o.configParser.GetTasksByTargetIds(o.desiredTargetIds)
-		if err != nil {
-			return nil, err
-		}
-		taskWhitelist = append(taskWhitelist, tasks...)
-	}
-
-	return getUniqueTaskNames(taskWhitelist), nil
 }
 
 func (o *pipelineOptionsCreator) getStagesBlacklist() []pipeline.StageName {

--- a/indexer/pipeline_options_creator_test.go
+++ b/indexer/pipeline_options_creator_test.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/figment-networks/indexing-engine/pipeline"
@@ -11,13 +10,15 @@ import (
 )
 
 func TestPipelineOptionsCreator_parse(t *testing.T) {
+	expectTasks := []pipeline.TaskName{"Task1", "Task2"}
+
 	t.Run("when version ids are given, return tasks white list", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		configParserMock := mock.NewMockConfigParser(ctrl)
 
-		configParserMock.EXPECT().GetTasksByVersionIds(gomock.Any()).Return([]pipeline.TaskName{"task1", "task2"}, nil).Times(1)
+		configParserMock.EXPECT().GetAllTasks(gomock.Any(), gomock.Any()).Return(expectTasks, nil).Times(1)
 
 		creator := pipelineOptionsCreator{
 			configParser: configParserMock,
@@ -39,11 +40,15 @@ func TestPipelineOptionsCreator_parse(t *testing.T) {
 			t.Errorf("unexpected TaskWhitelist size, want: %d; got: %d", 2, len(options.TaskWhitelist))
 		}
 
-		for i, gotTaskName := range options.TaskWhitelist {
-			wantTaskName := fmt.Sprintf("task%d", i+1)
-
-			if string(gotTaskName) != wantTaskName {
-				t.Errorf("unexpected task at index %d, want: %s; got: %s", i, wantTaskName, gotTaskName)
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range options.TaskWhitelist {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, options.TaskWhitelist)
 			}
 		}
 	})
@@ -54,7 +59,7 @@ func TestPipelineOptionsCreator_parse(t *testing.T) {
 
 		configParserMock := mock.NewMockConfigParser(ctrl)
 
-		configParserMock.EXPECT().GetTasksByTargetIds(gomock.Any()).Return([]pipeline.TaskName{"task1", "task2"}, nil).Times(1)
+		configParserMock.EXPECT().GetAllTasks(gomock.Any(), gomock.Any()).Return(expectTasks, nil).Times(1)
 
 		creator := pipelineOptionsCreator{
 			configParser: configParserMock,
@@ -76,11 +81,15 @@ func TestPipelineOptionsCreator_parse(t *testing.T) {
 			t.Errorf("unexpected TaskWhitelist size, want: %d; got: %d", 2, len(options.TaskWhitelist))
 		}
 
-		for i, gotTaskName := range options.TaskWhitelist {
-			wantTaskName := fmt.Sprintf("task%d", i+1)
-
-			if string(gotTaskName) != wantTaskName {
-				t.Errorf("unexpected task at index %d, want: %s; got: %s", i, wantTaskName, gotTaskName)
+		for _, want := range expectTasks {
+			var found bool
+			for _, got := range options.TaskWhitelist {
+				if got == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected to find task want: %v; got: %v", want, options.TaskWhitelist)
 			}
 		}
 	})
@@ -90,6 +99,7 @@ func TestPipelineOptionsCreator_parse(t *testing.T) {
 		defer ctrl.Finish()
 
 		configParserMock := mock.NewMockConfigParser(ctrl)
+		configParserMock.EXPECT().GetAllTasks(gomock.Any(), gomock.Any()).Return([]pipeline.TaskName{}, nil).Times(1)
 
 		creator := pipelineOptionsCreator{
 			configParser: configParserMock,
@@ -124,7 +134,7 @@ func TestPipelineOptionsCreator_parse(t *testing.T) {
 		configParserMock := mock.NewMockConfigParser(ctrl)
 
 		testError := errors.New("test error")
-		configParserMock.EXPECT().GetTasksByTargetIds(gomock.Any()).Return(nil, testError).Times(1)
+		configParserMock.EXPECT().GetAllTasks(gomock.Any(), gomock.Any()).Return(nil, testError).Times(1)
 
 		creator := pipelineOptionsCreator{
 			configParser: configParserMock,

--- a/indexer_config.json
+++ b/indexer_config.json
@@ -49,13 +49,19 @@
         "MainSyncer",
         "SyncerPersistor"
     ],
+    "incompatible_tasks": [
+      {
+        "name": "FetchAll",
+        "blacklist": ["ValidatorPerformanceFetcher"]
+      }
+    ],
     "available_targets": [
       {
         "id": 1,
         "name": "index_block_sequences",
         "desc": "Creates and persists block sequences",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "BlockParser",
           "BlockSeqCreator",
           "BlockSeqPersistor"
@@ -76,7 +82,7 @@
         "name": "index_validator_era_sequences",
         "desc": "Creates and persists validator era sequences",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "ValidatorEraSeqCreator",
           "ValidatorEraSeqPersistor"
         ]
@@ -86,7 +92,7 @@
         "name": "index_validator_aggregates",
         "desc": "Creates and persists validator aggregates",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "ValidatorsParser",
           "ValidatorAggCreator",
           "ValidatorAggPersistor"
@@ -97,7 +103,7 @@
         "name": "index_event_sequences",
         "desc": "Creates and persists event sequences",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "EventSeqCreator",
           "EventSeqPersistor"
         ]
@@ -107,7 +113,7 @@
         "name": "index_account_era_sequences",
         "desc": "Creates and persists account era sequences",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "AccountEraSeqCreator",
           "AccountEraSeqPersistor"
         ]
@@ -117,7 +123,7 @@
         "name": "index_transaction_sequences",
         "desc": "Creates and persists transaction sequences",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "TransactionSeqCreator",
           "TransactionSeqPersistor"
         ]
@@ -137,7 +143,7 @@
         "name": "index_system_events",
         "desc": "Creates and persists system events that happen per height",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "ValidatorFetcher",
           "ValidatorSeqCreator",
           "SystemEventCreator",
@@ -149,7 +155,7 @@
         "name": "index_session_system_events",
         "desc": "Creates and persists system events that happen end of session",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "ValidatorSessionSeqCreator",
           "SessionSystemEventCreator",
           "SystemEventPersistor"
@@ -160,7 +166,7 @@
         "name": "index_era_system_events",
         "desc": "Creates and persists system events that happen end of era",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "AccountEraSeqCreator",
           "EraSystemEventCreator",
           "SystemEventPersistor"
@@ -171,7 +177,7 @@
         "name": "index_rewards",
         "desc": "Creates and persists rewards",
         "tasks": [
-          "Fetcher",
+          "FetchAll",
           "ValidatorsParser",
           "RewardEraSeqCreator",
           "RewardEraSeqPersistor"

--- a/indexer_config.json
+++ b/indexer_config.json
@@ -66,7 +66,7 @@
         "name": "index_validator_session_sequences",
         "desc": "Creates and persists validator session sequences",
         "tasks": [
-          "Fetcher",
+          "ValidatorPerformanceFetcher",
           "ValidatorSessionSeqCreator",
           "ValidatorSessionSeqPersistor"
         ]

--- a/mock/indexer/mocks.go
+++ b/mock/indexer/mocks.go
@@ -36,33 +36,19 @@ func (m *MockConfigParser) EXPECT() *MockConfigParserMockRecorder {
 	return m.recorder
 }
 
-// GetAllAvailableTasks mocks base method
-func (m *MockConfigParser) GetAllAvailableTasks() []pipeline.TaskName {
+// GetAllTasks mocks base method
+func (m *MockConfigParser) GetAllTasks(arg0, arg1 []int64) ([]pipeline.TaskName, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAvailableTasks")
-	ret0, _ := ret[0].([]pipeline.TaskName)
-	return ret0
-}
-
-// GetAllAvailableTasks indicates an expected call of GetAllAvailableTasks
-func (mr *MockConfigParserMockRecorder) GetAllAvailableTasks() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAvailableTasks", reflect.TypeOf((*MockConfigParser)(nil).GetAllAvailableTasks))
-}
-
-// GetAllVersionedTasks mocks base method
-func (m *MockConfigParser) GetAllVersionedTasks() ([]pipeline.TaskName, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllVersionedTasks")
+	ret := m.ctrl.Call(m, "GetAllTasks", arg0, arg1)
 	ret0, _ := ret[0].([]pipeline.TaskName)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAllVersionedTasks indicates an expected call of GetAllVersionedTasks
-func (mr *MockConfigParserMockRecorder) GetAllVersionedTasks() *gomock.Call {
+// GetAllTasks indicates an expected call of GetAllTasks
+func (mr *MockConfigParserMockRecorder) GetAllTasks(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllVersionedTasks", reflect.TypeOf((*MockConfigParser)(nil).GetAllVersionedTasks))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTasks", reflect.TypeOf((*MockConfigParser)(nil).GetAllTasks), arg0, arg1)
 }
 
 // GetAllVersionedVersionIds mocks base method
@@ -91,36 +77,6 @@ func (m *MockConfigParser) GetCurrentVersionId() int64 {
 func (mr *MockConfigParserMockRecorder) GetCurrentVersionId() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentVersionId", reflect.TypeOf((*MockConfigParser)(nil).GetCurrentVersionId))
-}
-
-// GetTasksByTargetIds mocks base method
-func (m *MockConfigParser) GetTasksByTargetIds(arg0 []int64) ([]pipeline.TaskName, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTasksByTargetIds", arg0)
-	ret0, _ := ret[0].([]pipeline.TaskName)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTasksByTargetIds indicates an expected call of GetTasksByTargetIds
-func (mr *MockConfigParserMockRecorder) GetTasksByTargetIds(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasksByTargetIds", reflect.TypeOf((*MockConfigParser)(nil).GetTasksByTargetIds), arg0)
-}
-
-// GetTasksByVersionIds mocks base method
-func (m *MockConfigParser) GetTasksByVersionIds(arg0 []int64) ([]pipeline.TaskName, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTasksByVersionIds", arg0)
-	ret0, _ := ret[0].([]pipeline.TaskName)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTasksByVersionIds indicates an expected call of GetTasksByVersionIds
-func (mr *MockConfigParserMockRecorder) GetTasksByVersionIds(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasksByVersionIds", reflect.TypeOf((*MockConfigParser)(nil).GetTasksByVersionIds), arg0)
 }
 
 // GetTransactionKinds mocks base method

--- a/usecase/validator/get_by_height.go
+++ b/usecase/validator/get_by_height.go
@@ -62,6 +62,11 @@ func (uc *getByHeightUseCase) Execute(height *int64) (SeqListView, error) {
 		return SeqListView{}, errors.New("height is not indexed yet")
 	}
 
+	eraSeqs, err := uc.validatorDb.FindEraSeqsByHeight(*height)
+	if err != nil && err != store.ErrNotFound {
+		return SeqListView{}, err
+	}
+
 	sessionSeqs, err := uc.validatorDb.FindSessionSeqsByHeight(*height)
 	if len(sessionSeqs) == 0 || err != nil {
 		syncable, err := uc.syncableDb.FindLastInSessionForHeight(*height)
@@ -85,11 +90,6 @@ func (uc *getByHeightUseCase) Execute(height *int64) (SeqListView, error) {
 		}
 
 		sessionSeqs = payload.ValidatorSessionSequences
-	}
-
-	eraSeqs, err := uc.validatorDb.FindEraSeqsByHeight(*height)
-	if err != nil && err != store.ErrNotFound {
-		return SeqListView{}, err
 	}
 
 	return ToSeqListView(sessionSeqs, eraSeqs), nil


### PR DESCRIPTION
- adds new field to indexer_config called `incompatible_tasks`. Idea is that if `FetchAll` is running, then we should not also run `ValidatorPerformanceFetcher` (or other fetchers in the future).

was necessary to change `Fetcher` task name because `ValidatorPerformanceFetcher` was matching in whitelist because of [this](https://github.com/figment-networks/indexing-engine/blob/master/pipeline/stage.go#L62) (decided not to update pipeline code because maybe other indexers rely on this bug)

running this locally, previously it took 30s with Fetcher (where height being fetched was also end of era), and with these changes using `ValidatorPerformanceFetcher` it took <1s.

validator sequences aren't being persisted because pipeline is run in dry mode [see here](https://github.com/figment-networks/polkadothub-indexer/pull/64/files#diff-92c51779b964cc492f0f9fa9143a0f6c755176294848c3e7872b244202be009fR86). Dry mode blacklists persistor stage.