### PR TITLE
Update apr query and resp

### DIFF
--- a/usecase/apr/get_apr_by_address_http_handler.go
+++ b/usecase/apr/get_apr_by_address_http_handler.go
@@ -30,29 +30,20 @@ func NewGetAprByAddressHttpHandler(accountDb store.AccountEraSeq, rewardDb store
 	}
 }
 
-type uriParams struct {
-	Address string `uri:"stash_account" binding:"required"`
-}
-
 type queryParams struct {
-	Start time.Time `form:"start" binding:"required" time_format:"2006-01-02"`
-	End   time.Time `form:"end" binding:"-" time_format:"2006-01-02"`
+	Account string    `form:"acount" binding:"required"`
+	Start   time.Time `form:"start_time" binding:"required" time_format:"2006-01-02"`
+	End     time.Time `form:"end_time" binding:"-" time_format:"2006-01-02"`
 }
 
 func (h *getAprByAddressHttpHandler) Handle(c *gin.Context) {
-	var req uriParams
-	if err := c.ShouldBindUri(&req); err != nil {
-		http.BadRequest(c, errors.New("missing parameter"))
-		return
-	}
-
 	var params queryParams
 	if err := c.ShouldBindQuery(&params); err != nil {
-		http.BadRequest(c, errors.New("invalid start and/or end date"))
+		http.BadRequest(c, errors.New("required start_time or account is missing, and/or start_time end_time must be in format: 2006-01-02"))
 		return
 	}
 
-	resp, err := h.getUseCase().Execute(req.Address, *types.NewTimeFromTime(params.Start), *types.NewTimeFromTime(params.End))
+	resp, err := h.getUseCase().Execute(params.Account, *types.NewTimeFromTime(params.Start), *types.NewTimeFromTime(params.End))
 	if http.ShouldReturn(c, err) {
 		return
 	}

--- a/usecase/apr/views.go
+++ b/usecase/apr/views.go
@@ -8,15 +8,17 @@ import (
 )
 
 var (
-	daysInYear = big.NewFloat(365)
+	daysInYear   = big.NewFloat(365)
+	decPrecision = 4
 )
 
 type DailyApr struct {
-	TimeBucket   types.Time     `json:"time"`
+	TimeBucket   types.Time     `json:"time_bucket"`
 	Era          int64          `json:"era"`
 	Bonded       types.Quantity `json:"bonded"`
 	TotalRewards types.Quantity `json:"total_rewards"`
-	APR          big.Float      `json:"apr"`
+	APR          string         `json:"apr"`
+	Validator    string         `json:"validator"`
 }
 
 func dailyAPR(rewardSeq model.RewardEraSeq, stake types.Quantity) (DailyApr, error) {
@@ -37,7 +39,8 @@ func dailyAPR(rewardSeq model.RewardEraSeq, stake types.Quantity) (DailyApr, err
 		Era:          rewardSeq.Era,
 		Bonded:       stake,
 		TotalRewards: reward,
-		APR:          *apr,
+		APR:          apr.Text('f', decPrecision),
+		Validator:    rewardSeq.ValidatorStashAccount,
 	}, nil
 }
 


### PR DESCRIPTION
Updated response and query to be more consistent with /apr from other networks. 

See [oasis](https://github.com/figment-networks/oasishub-indexer/blob/master/usecase/apr/views.go)